### PR TITLE
Bugfix/general bugfixes improvements

### DIFF
--- a/scripts/seed-participants.ts
+++ b/scripts/seed-participants.ts
@@ -1,0 +1,466 @@
+/**
+ * Seeds 200 test participants with varied attributes for testing auto-assign.
+ * Also creates 10 teams with standard role slots.
+ *
+ * Usage: npx tsx scripts/seed-participants.ts
+ * Clean:  npx tsx scripts/seed-participants.ts --clean
+ */
+
+import { MongoClient, ObjectId } from "mongodb";
+import bcrypt from "bcryptjs";
+
+const MONGO_URI =
+  process.env.MONGO_DB_URI || "mongodb://localhost:27017/promptengineers";
+const HACKATHON_SLUG = "test";
+const PARTICIPANT_COUNT = 200;
+const TEAM_COUNT = 10;
+
+const ROLES = [
+  "Product Manager",
+  "UI/UX Designer",
+  "Prompt/AI Engineer",
+  "Backend Engineer",
+  "Frontend Developer",
+  "Flex",
+] as const;
+
+const SKILL_BACKGROUNDS = [
+  "Frontend development",
+  "Backend development",
+  "Data / Machine Learning / AI",
+  "Design / UX",
+  "Product Management",
+  "DevOps / Infrastructure",
+  "Non-technical (learning AI tools)",
+] as const;
+
+const AI_EXPERIENCE_LEVELS = [
+  "Beginner (played with APIs / tools)",
+  "Intermediate (built small projects)",
+  "Advanced (production experience)",
+] as const;
+
+const INVOLVEMENTS = ["participant", "volunteer", "mentor"] as const;
+
+// Weighted distribution to create realistic imbalances
+// More backend/frontend, fewer PM/UX — mirrors real hackathon signups
+const ROLE_PREFERENCE_WEIGHTS: {
+  role: (typeof ROLES)[number];
+  weight: number;
+}[] = [
+  { role: "Backend Engineer", weight: 30 },
+  { role: "Frontend Developer", weight: 25 },
+  { role: "Prompt/AI Engineer", weight: 20 },
+  { role: "UI/UX Designer", weight: 10 },
+  { role: "Product Manager", weight: 8 },
+  { role: "Flex", weight: 7 },
+];
+
+const EXPERIENCE_WEIGHTS: {
+  exp: (typeof AI_EXPERIENCE_LEVELS)[number];
+  weight: number;
+}[] = [
+  { exp: "Beginner (played with APIs / tools)", weight: 40 },
+  { exp: "Intermediate (built small projects)", weight: 35 },
+  { exp: "Advanced (production experience)", weight: 25 },
+];
+
+const FIRST_NAMES = [
+  "Alex",
+  "Jordan",
+  "Taylor",
+  "Morgan",
+  "Casey",
+  "Riley",
+  "Quinn",
+  "Avery",
+  "Cameron",
+  "Dakota",
+  "Drew",
+  "Emery",
+  "Finley",
+  "Harper",
+  "Jamie",
+  "Kendall",
+  "Logan",
+  "Micah",
+  "Nico",
+  "Parker",
+  "Reese",
+  "Sage",
+  "Skyler",
+  "Tatum",
+  "Hayden",
+  "Blake",
+  "Charlie",
+  "Devon",
+  "Ellis",
+  "Frankie",
+  "Gray",
+  "Harley",
+  "Indigo",
+  "Jules",
+  "Kit",
+  "Lane",
+  "Marlo",
+  "Noel",
+  "Oakley",
+  "Peyton",
+  "Remy",
+  "Sam",
+  "Toby",
+  "Val",
+  "Winter",
+  "Xen",
+  "Yael",
+  "Zion",
+  "Aria",
+  "Kai",
+  "Mika",
+  "Sasha",
+  "River",
+  "Ash",
+  "Wren",
+  "Jude",
+  "Eden",
+  "Rowan",
+  "Phoenix",
+  "Robin",
+  "Shay",
+  "Lennox",
+  "Raven",
+  "Storm",
+];
+
+const LAST_NAMES = [
+  "Chen",
+  "Park",
+  "Singh",
+  "Kim",
+  "Torres",
+  "Wu",
+  "Patel",
+  "Garcia",
+  "Zhang",
+  "Ali",
+  "Nguyen",
+  "Lee",
+  "Martinez",
+  "Brown",
+  "Johnson",
+  "Davis",
+  "Wilson",
+  "Moore",
+  "Taylor",
+  "Anderson",
+  "Thomas",
+  "Jackson",
+  "White",
+  "Harris",
+  "Thompson",
+  "Clark",
+  "Lewis",
+  "Walker",
+  "Hall",
+  "Young",
+  "Scott",
+  "Adams",
+  "Nelson",
+  "Hill",
+  "King",
+  "Wright",
+  "Green",
+  "Baker",
+  "Rivera",
+  "Campbell",
+  "Reed",
+  "Cook",
+  "Bell",
+  "Murphy",
+  "Cooper",
+  "Ross",
+  "Morgan",
+  "Brooks",
+];
+
+function weightedRandom<T>(items: { weight: number }[], values: T[]): T {
+  const total = items.reduce((sum, i) => sum + i.weight, 0);
+  let r = Math.random() * total;
+  for (let i = 0; i < items.length; i++) {
+    r -= items[i].weight;
+    if (r <= 0) return values[i];
+  }
+  return values[values.length - 1];
+}
+
+function pickRandom<T>(arr: readonly T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+async function main() {
+  const isClean = process.argv.includes("--clean");
+  const client = new MongoClient(MONGO_URI);
+
+  try {
+    await client.connect();
+    const db = client.db();
+
+    const hackathon = await db
+      .collection("hackathons")
+      .findOne({ slug: HACKATHON_SLUG });
+    if (!hackathon) {
+      console.error(
+        `Hackathon "${HACKATHON_SLUG}" not found. Create it first.`,
+      );
+      process.exit(1);
+    }
+
+    const hackathonId = hackathon._id;
+
+    if (isClean) {
+      // Clean up seeded data
+      const deleteUsers = await db.collection("users").deleteMany({
+        email: { $regex: /^testparticipant\d+@test\.com$/ },
+      });
+      const deleteProfiles = await db.collection("profiles").deleteMany({
+        skillBackground: { $exists: true },
+        userId: { $exists: true },
+      });
+      const deleteRegs = await db
+        .collection("hackathonRegistrations")
+        .deleteMany({
+          hackathonId,
+        });
+      const deleteTeams = await db.collection("hackathonTeams").deleteMany({
+        hackathonId,
+      });
+      console.log(
+        `Cleaned: ${deleteUsers.deletedCount} users, ${deleteProfiles.deletedCount} profiles, ${deleteRegs.deletedCount} registrations, ${deleteTeams.deletedCount} teams`,
+      );
+      await client.close();
+      return;
+    }
+
+    const passwordHash = await bcrypt.hash("password", 12);
+    const now = new Date();
+
+    // --- Distribution tracking ---
+    const stats = {
+      rolePreferences: {} as Record<string, number>,
+      skillBackgrounds: {} as Record<string, number>,
+      experienceLevels: {} as Record<string, number>,
+      involvements: {} as Record<string, number>,
+      noRolePref: 0,
+    };
+
+    console.log(
+      `\nSeeding ${PARTICIPANT_COUNT} participants for hackathon "${HACKATHON_SLUG}"...\n`,
+    );
+
+    const userDocs: Record<string, unknown>[] = [];
+    const profileDocs: Record<string, unknown>[] = [];
+    const registrationDocs: Record<string, unknown>[] = [];
+
+    for (let i = 0; i < PARTICIPANT_COUNT; i++) {
+      const userId = new ObjectId();
+      const firstName = pickRandom(FIRST_NAMES);
+      const lastName = pickRandom(LAST_NAMES);
+      const name = `${firstName} ${lastName}`;
+      const email = `testparticipant${i + 1}@test.com`;
+
+      // 85% have a role preference, 15% don't (to test fallback to skillBackground)
+      const hasRolePref = Math.random() < 0.85;
+      const rolePreference = hasRolePref
+        ? weightedRandom(
+            ROLE_PREFERENCE_WEIGHTS,
+            ROLE_PREFERENCE_WEIGHTS.map((r) => r.role),
+          )
+        : undefined;
+
+      const skillBackground = pickRandom(SKILL_BACKGROUNDS);
+      const aiExperience = weightedRandom(
+        EXPERIENCE_WEIGHTS,
+        EXPERIENCE_WEIGHTS.map((e) => e.exp),
+      );
+
+      // 85% participant, 10% mentor, 5% volunteer
+      const involvementRoll = Math.random();
+      const involvement =
+        involvementRoll < 0.85
+          ? "participant"
+          : involvementRoll < 0.95
+            ? "mentor"
+            : "volunteer";
+
+      // Track stats
+      if (rolePreference) {
+        stats.rolePreferences[rolePreference] =
+          (stats.rolePreferences[rolePreference] || 0) + 1;
+      } else {
+        stats.noRolePref++;
+      }
+      stats.skillBackgrounds[skillBackground] =
+        (stats.skillBackgrounds[skillBackground] || 0) + 1;
+      stats.experienceLevels[aiExperience] =
+        (stats.experienceLevels[aiExperience] || 0) + 1;
+      stats.involvements[involvement] =
+        (stats.involvements[involvement] || 0) + 1;
+
+      userDocs.push({
+        _id: userId,
+        email,
+        passwordHash,
+        name,
+        isAdmin: false,
+        emailVerified: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      profileDocs.push({
+        userId,
+        skillBackground,
+        aiExperience,
+        isPublic: true,
+        badges: ["hackathon"],
+        links: {},
+        background: "",
+        seeking: "networking",
+        avatarUrl: "",
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      registrationDocs.push({
+        hackathonId,
+        userId: userId.toString(),
+        involvement,
+        ...(rolePreference ? { rolePreference } : {}),
+        registeredAt: now,
+      });
+    }
+
+    // Bulk insert
+    await db.collection("users").insertMany(userDocs);
+    await db.collection("profiles").insertMany(profileDocs);
+    await db.collection("hackathonRegistrations").insertMany(registrationDocs);
+
+    console.log(
+      `✓ Created ${PARTICIPANT_COUNT} users, profiles, and registrations\n`,
+    );
+
+    // --- Create teams ---
+    const teamDocs: Record<string, unknown>[] = [];
+    const admin = await db.collection("users").findOne({ isAdmin: true });
+    const createdBy = admin?._id?.toString() || userDocs[0]._id!.toString();
+
+    for (let i = 0; i < TEAM_COUNT; i++) {
+      teamDocs.push({
+        hackathonId,
+        name: `Team ${i + 1}`,
+        description: "",
+        order: i,
+        slots: ROLES.map((role) => ({
+          role,
+          userId: null,
+          required: [
+            "Backend Engineer",
+            "Frontend Developer",
+            "Prompt/AI Engineer",
+          ].includes(role),
+        })),
+        createdBy,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+
+    await db.collection("hackathonTeams").insertMany(teamDocs);
+    console.log(
+      `✓ Created ${TEAM_COUNT} teams (${ROLES.length} slots each = ${TEAM_COUNT * ROLES.length} total slots)\n`,
+    );
+
+    // --- Print distribution summary ---
+    console.log("═══════════════════════════════════════════");
+    console.log("  PARTICIPANT DISTRIBUTION SUMMARY");
+    console.log("═══════════════════════════════════════════\n");
+
+    console.log("Role Preferences:");
+    const sortedRoles = Object.entries(stats.rolePreferences).sort(
+      (a, b) => b[1] - a[1],
+    );
+    for (const [role, count] of sortedRoles) {
+      const bar = "█".repeat(Math.round(count / 2));
+      console.log(`  ${role.padEnd(22)} ${String(count).padStart(3)} ${bar}`);
+    }
+    console.log(
+      `  ${"(no preference)".padEnd(22)} ${String(stats.noRolePref).padStart(3)}`,
+    );
+
+    console.log("\nSkill Backgrounds:");
+    const sortedSkills = Object.entries(stats.skillBackgrounds).sort(
+      (a, b) => b[1] - a[1],
+    );
+    for (const [skill, count] of sortedSkills) {
+      const bar = "█".repeat(Math.round(count / 2));
+      console.log(`  ${skill.padEnd(35)} ${String(count).padStart(3)} ${bar}`);
+    }
+
+    console.log("\nExperience Levels:");
+    const sortedExp = Object.entries(stats.experienceLevels).sort(
+      (a, b) => b[1] - a[1],
+    );
+    for (const [exp, count] of sortedExp) {
+      const bar = "█".repeat(Math.round(count / 2));
+      console.log(`  ${exp.padEnd(40)} ${String(count).padStart(3)} ${bar}`);
+    }
+
+    console.log("\nInvolvement Types:");
+    for (const [inv, count] of Object.entries(stats.involvements)) {
+      console.log(`  ${inv.padEnd(15)} ${String(count).padStart(3)}`);
+    }
+
+    console.log("\n═══════════════════════════════════════════");
+    console.log("  CAPACITY ANALYSIS");
+    console.log("═══════════════════════════════════════════\n");
+
+    const totalSlots = TEAM_COUNT * ROLES.length;
+    const slotsPerRole = TEAM_COUNT; // 1 slot per role per team
+    console.log(
+      `  Total team slots:     ${totalSlots} (${TEAM_COUNT} teams × ${ROLES.length} roles)`,
+    );
+    console.log(`  Total participants:   ${PARTICIPANT_COUNT}`);
+    console.log(
+      `  Overflow expected:    ${Math.max(0, PARTICIPANT_COUNT - totalSlots)} participants need new teams\n`,
+    );
+
+    console.log("  Slots vs Demand per Role:");
+    for (const role of ROLES) {
+      const demand = stats.rolePreferences[role] || 0;
+      const ratio = demand > 0 ? (demand / slotsPerRole).toFixed(1) : "0.0";
+      const status =
+        demand > slotsPerRole
+          ? "⚠ OVERFLOW"
+          : demand === slotsPerRole
+            ? "= EXACT"
+            : "✓ fits";
+      console.log(
+        `    ${role.padEnd(22)} ${String(slotsPerRole).padStart(2)} slots, ${String(demand).padStart(3)} want it  (${ratio}x)  ${status}`,
+      );
+    }
+
+    console.log(
+      `\n  No-preference participants (${stats.noRolePref}) will be placed by skillBackground mapping.\n`,
+    );
+    console.log(
+      "Done! Run auto-assign from the admin panel or via API to test.\n",
+    );
+  } catch (error) {
+    console.error("Error:", error);
+    process.exit(1);
+  } finally {
+    await client.close();
+  }
+}
+
+main();

--- a/src/app/api/hackathons/[slug]/register/route.ts
+++ b/src/app/api/hackathons/[slug]/register/route.ts
@@ -62,17 +62,18 @@ export async function POST(
     const parsed = await parseJsonBody(request);
     if (!parsed.ok) return parsed.response;
     const body = parsed.data;
-    const { involvement, rolePreference, skillBackground, aiExperience } =
-      body as {
-        involvement?: string;
-        rolePreference?: string;
-        skillBackground?: string;
-        aiExperience?: string;
-      };
+    const { involvement, skillBackground, aiExperience } = body as {
+      involvement?: string;
+      skillBackground?: string;
+      aiExperience?: string;
+    };
 
-    if (!involvement || !rolePreference || !skillBackground || !aiExperience) {
+    if (!involvement || !skillBackground || !aiExperience) {
       return NextResponse.json(
-        { error: "All fields are required: involvement, rolePreference, skillBackground, aiExperience" },
+        {
+          error:
+            "All fields are required: involvement, skillBackground, aiExperience",
+        },
         { status: 400 },
       );
     }
@@ -82,7 +83,6 @@ export async function POST(
       hackathonId: hackathon._id,
       userId: auth.user.id,
       involvement: involvement as HackathonInvolvement,
-      rolePreference: rolePreference as HackathonRole | undefined,
     });
 
     // Update profile with hackathon fields, badge, and make public

--- a/src/app/api/hackathons/[slug]/teams/auto-assign/route.ts
+++ b/src/app/api/hackathons/[slug]/teams/auto-assign/route.ts
@@ -7,10 +7,9 @@ import {
   updateHackathonTeam,
 } from "@/lib/models/HackathonTeam";
 import { getRegistrationsByHackathonId } from "@/lib/models/HackathonRegistration";
-import { getProfileByUserId } from "@/lib/models/Profile";
+import { getProfilesByUserIds } from "@/lib/models/Profile";
 import type { HackathonRole, HackathonTeamSlot } from "@/types";
 
-// Map skillBackground to closest hackathon role
 const SKILL_TO_ROLE: Record<string, HackathonRole> = {
   "Frontend development": "Frontend Developer",
   "Backend development": "Backend Engineer",
@@ -21,10 +20,36 @@ const SKILL_TO_ROLE: Record<string, HackathonRole> = {
   "Non-technical (learning AI tools)": "Flex",
 };
 
+const EXPERIENCE_RANK: Record<string, number> = {
+  "Advanced (production experience)": 3,
+  "Intermediate (built small projects)": 2,
+  "Beginner (played with APIs / tools)": 1,
+};
+
+const EXP_LABEL: Record<number, string> = {
+  3: "Adv",
+  2: "Int",
+  1: "Beg",
+  0: "Unk",
+};
+
 interface ParticipantInfo {
   userId: string;
   rolePreference?: string;
   skillBackground?: string;
+  aiExperience?: string;
+}
+
+interface TaggedParticipant extends ParticipantInfo {
+  bestRole: HackathonRole;
+  expRank: number;
+}
+
+interface MutableTeam {
+  id: string;
+  name: string;
+  slots: { role: HackathonRole; userId?: string; required: boolean }[];
+  isNew: boolean;
 }
 
 // POST /api/hackathons/[slug]/teams/auto-assign
@@ -44,34 +69,39 @@ export async function POST(
       );
     }
 
-    // Gather all data
     const [teams, registrations] = await Promise.all([
       getTeamsByHackathonId(hackathon._id),
       getRegistrationsByHackathonId(hackathon._id),
     ]);
 
-    // Build participant info with profiles
-    const participants: ParticipantInfo[] = await Promise.all(
-      registrations.map(async (reg) => {
-        const profile = await getProfileByUserId(reg.userId);
-        return {
-          userId: reg.userId,
-          rolePreference: reg.rolePreference || undefined,
-          skillBackground: profile?.skillBackground || undefined,
-        };
-      }),
-    );
+    const userIds = registrations.map((r) => r.userId);
+    const profileMap = await getProfilesByUserIds(userIds);
 
-    // Find already-assigned user IDs
+    const participants: ParticipantInfo[] = registrations.map((reg) => {
+      const profile = profileMap.get(reg.userId);
+      return {
+        userId: reg.userId,
+        rolePreference: reg.rolePreference || undefined,
+        skillBackground: profile?.skillBackground || undefined,
+        aiExperience: profile?.aiExperience || undefined,
+      };
+    });
+
     const assignedUserIds = new Set(
       teams.flatMap((t) =>
         t.slots.filter((s) => s.userId).map((s) => s.userId!),
       ),
     );
 
-    // Unassigned participants
     const unassigned = participants.filter(
       (p) => !assignedUserIds.has(p.userId),
+    );
+
+    console.log("\n══════════════════════════════════════════════");
+    console.log("  AUTO-ASSIGN START");
+    console.log("══════════════════════════════════════════════");
+    console.log(
+      `  Registrations: ${participants.length}, Assigned: ${assignedUserIds.size}, Unassigned: ${unassigned.length}, Teams: ${teams.length}`,
     );
 
     if (unassigned.length === 0) {
@@ -82,40 +112,52 @@ export async function POST(
       });
     }
 
-    // Determine best role for each participant
+    // --- Tag participants ---
+    // Role is derived from skillBackground via SKILL_TO_ROLE mapping
     const getBestRole = (p: ParticipantInfo): HackathonRole => {
-      if (
-        p.rolePreference &&
-        hackathon!.roles.includes(p.rolePreference as HackathonRole)
-      ) {
-        return p.rolePreference as HackathonRole;
-      }
       if (p.skillBackground && SKILL_TO_ROLE[p.skillBackground]) {
         const mapped = SKILL_TO_ROLE[p.skillBackground];
-        if (hackathon!.roles.includes(mapped)) {
-          return mapped;
-        }
+        if (hackathon.roles.includes(mapped)) return mapped;
       }
       return "Flex";
     };
 
-    // Score participants: those with clear preferences first
-    const scored = unassigned.map((p) => ({
+    const getExpRank = (p: ParticipantInfo): number =>
+      (p.aiExperience && EXPERIENCE_RANK[p.aiExperience]) || 0;
+
+    const tagged: TaggedParticipant[] = unassigned.map((p) => ({
       ...p,
       bestRole: getBestRole(p),
-      priority: p.rolePreference ? 0 : p.skillBackground ? 1 : 2,
+      expRank: getExpRank(p),
     }));
-    scored.sort((a, b) => a.priority - b.priority);
 
-    // Collect mutable team slot state
-    interface MutableTeam {
-      id: string;
-      slots: { role: HackathonRole; userId?: string; required: boolean }[];
-      isNew: boolean;
+    // Log role groups
+    const roleGroups = new Map<HackathonRole, TaggedParticipant[]>();
+    for (const p of tagged) {
+      const group = roleGroups.get(p.bestRole) || [];
+      group.push(p);
+      roleGroups.set(p.bestRole, group);
     }
 
+    console.log("\n  Role Groups:");
+    for (const role of Array.from(roleGroups.keys())) {
+      const group = roleGroups.get(role)!;
+      const exp = [3, 2, 1, 0]
+        .map((r) => {
+          const c = group.filter((p) => p.expRank === r).length;
+          return c > 0 ? `${EXP_LABEL[r]}:${c}` : null;
+        })
+        .filter(Boolean)
+        .join(" ");
+      console.log(
+        `    ${role.padEnd(22)} ${String(group.length).padStart(3)}  [${exp}]`,
+      );
+    }
+
+    // --- Build mutable team state ---
     const mutableTeams: MutableTeam[] = teams.map((t) => ({
       id: t._id,
+      name: t.name,
       slots: t.slots.map((s) => ({
         role: s.role as HackathonRole,
         userId: s.userId || undefined,
@@ -127,101 +169,246 @@ export async function POST(
     let teamsCreated = 0;
     let assigned = 0;
 
-    const findOpenSlot = (
-      role: HackathonRole,
-    ): { team: MutableTeam; slotIndex: number } | null => {
-      // Prefer teams with more empty required slots (spread evenly)
-      const sorted = [...mutableTeams].sort((a, b) => {
-        const aEmpty = a.slots.filter((s) => !s.userId && s.required).length;
-        const bEmpty = b.slots.filter((s) => !s.userId && s.required).length;
-        return bEmpty - aEmpty; // more empty = higher priority
-      });
-
-      for (const team of sorted) {
-        const idx = team.slots.findIndex((s) => s.role === role && !s.userId);
-        if (idx !== -1) return { team, slotIndex: idx };
-      }
-      return null;
-    };
-
     const createNewTeam = (): MutableTeam => {
       teamsCreated++;
+      const teamNum = teams.length + teamsCreated;
       const newTeam: MutableTeam = {
-        id: `new-${mutableTeams.length + 1}`,
-        slots: hackathon!.roles.map((role) => ({
-          role,
-          userId: undefined,
-          required: hackathon!.requiredRoles.includes(role),
-        })),
+        id: `new-${teamNum}`,
+        name: `Team ${teamNum}`,
+        slots: [
+          ...hackathon.roles.map((role) => ({
+            role,
+            userId: undefined,
+            required: hackathon.requiredRoles.includes(role),
+          })),
+          ...Array.from(
+            {
+              length: Math.max(
+                0,
+                hackathon.maxTeamSize - hackathon.roles.length,
+              ),
+            },
+            () => ({
+              role: "Flex" as HackathonRole,
+              userId: undefined,
+              required: false,
+            }),
+          ),
+        ].slice(0, hackathon.maxTeamSize),
         isNew: true,
       };
       mutableTeams.push(newTeam);
       return newTeam;
     };
 
-    // Phase 1: Fill required roles first
-    const requiredFirst = scored.filter((p) => p.bestRole !== "Flex");
-    const flexParticipants = scored.filter((p) => p.bestRole === "Flex");
+    // --- Pre-create teams so we have enough capacity ---
+    // Calculate how many total slots exist vs participants to place.
+    // Create all needed teams upfront so the balancing algorithm can
+    // spread participants evenly across ALL teams from the start.
+    const slotsPerTeam = hackathon.roles.length;
+    const existingOpenSlots = mutableTeams.reduce(
+      (sum, t) => sum + t.slots.filter((s) => !s.userId).length,
+      0,
+    );
+    const extraSlotsNeeded = tagged.length - existingOpenSlots;
+    const extraTeamsNeeded = Math.max(
+      0,
+      Math.ceil(extraSlotsNeeded / slotsPerTeam),
+    );
 
-    for (const p of requiredFirst) {
-      let match = findOpenSlot(p.bestRole);
+    if (extraTeamsNeeded > 0) {
+      console.log(
+        `\n  Pre-creating ${extraTeamsNeeded} teams (${existingOpenSlots} open slots, ${tagged.length} to place)`,
+      );
+      for (let i = 0; i < extraTeamsNeeded; i++) {
+        createNewTeam();
+      }
+    }
 
-      // No open slot for preferred role — try Flex
-      if (!match) {
-        match = findOpenSlot("Flex");
+    // Experience total for a team (used to balance placement)
+    const teamExpTotal = (t: MutableTeam): number => {
+      let total = 0;
+      for (const slot of t.slots) {
+        if (slot.userId) {
+          const p = tagged.find((tp) => tp.userId === slot.userId);
+          if (p) total += p.expRank;
+        }
+      }
+      return total;
+    };
+
+    const teamFillCount = (t: MutableTeam): number =>
+      t.slots.filter((s) => s.userId).length;
+
+    // ================================================================
+    //  SINGLE-PASS ALGORITHM: Global experience-balanced assignment
+    //
+    //  1. Sort ALL participants by experience desc (Advanced first)
+    //  2. For each participant, find the best placement:
+    //     a. Exact role match on team with LOWEST experience total
+    //     b. Any open slot on team with LOWEST experience total
+    //     c. Create new team with their preferred role
+    //
+    //  By processing experienced people first and always placing them
+    //  on the team with the lowest total experience, we naturally
+    //  spread talent evenly. Each Advanced person goes to a different
+    //  team before any team gets a second one (assuming enough teams).
+    // ================================================================
+
+    // Sort by experience descending — most experienced placed first
+    const sorted = [...tagged].sort((a, b) => b.expRank - a.expRank);
+
+    console.log("\n  Assigning participants (experience-balanced)...");
+
+    let placedInRole = 0;
+    let placedInAny = 0;
+    let placedInNewTeam = 0;
+
+    for (const p of sorted) {
+      // Find all teams with an open slot matching this participant's role
+      // Pick the one with the lowest experience total
+      let bestMatch: { team: MutableTeam; slotIndex: number } | null = null;
+      let bestScore = Infinity;
+      let placementType = "role";
+
+      // Try exact role match
+      for (const team of mutableTeams) {
+        const idx = team.slots.findIndex(
+          (s) => s.role === p.bestRole && !s.userId,
+        );
+        if (idx !== -1) {
+          const score = teamExpTotal(team) * 100 + teamFillCount(team);
+          if (score < bestScore) {
+            bestScore = score;
+            bestMatch = { team, slotIndex: idx };
+          }
+        }
       }
 
-      // Still nothing — create a new team
-      if (!match) {
+      // No exact role match — try any open slot
+      if (!bestMatch) {
+        placementType = "any";
+        bestScore = Infinity;
+        for (const team of mutableTeams) {
+          const idx = team.slots.findIndex((s) => !s.userId);
+          if (idx !== -1) {
+            const score = teamExpTotal(team) * 100 + teamFillCount(team);
+            if (score < bestScore) {
+              bestScore = score;
+              bestMatch = { team, slotIndex: idx };
+            }
+          }
+        }
+      }
+
+      // Still nothing — create new team
+      if (!bestMatch) {
+        placementType = "new-team";
         const newTeam = createNewTeam();
         const idx = newTeam.slots.findIndex(
           (s) => s.role === p.bestRole && !s.userId,
         );
         if (idx !== -1) {
-          match = { team: newTeam, slotIndex: idx };
+          bestMatch = { team: newTeam, slotIndex: idx };
         } else {
-          // Role doesn't exist in default slots, use first open
           const firstOpen = newTeam.slots.findIndex((s) => !s.userId);
           if (firstOpen !== -1) {
-            match = { team: newTeam, slotIndex: firstOpen };
+            bestMatch = { team: newTeam, slotIndex: firstOpen };
           }
         }
       }
 
-      if (match) {
-        match.team.slots[match.slotIndex].userId = p.userId;
+      if (bestMatch) {
+        bestMatch.team.slots[bestMatch.slotIndex].userId = p.userId;
         assigned++;
+        if (placementType === "role") placedInRole++;
+        else if (placementType === "any") placedInAny++;
+        else placedInNewTeam++;
       }
     }
 
-    // Phase 2: Fill Flex participants
-    for (const p of flexParticipants) {
-      let match = findOpenSlot("Flex");
+    console.log(`    Placed in preferred role: ${placedInRole}`);
+    console.log(`    Placed in other slot:     ${placedInAny}`);
+    console.log(`    Placed in new teams:      ${placedInNewTeam}`);
 
-      // No Flex slot — find any open slot
-      if (!match) {
-        for (const role of hackathon.roles) {
-          match = findOpenSlot(role);
-          if (match) break;
+    // --- Log final composition ---
+    console.log("\n  Final Team Composition:");
+    console.log("  " + "─".repeat(55));
+    console.log(
+      `  ${"Team".padEnd(20)} ${"Fill".padStart(5)}  ${"Adv".padStart(4)} ${"Int".padStart(4)} ${"Beg".padStart(4)}  ${"ExpTot".padStart(6)}`,
+    );
+    console.log("  " + "─".repeat(55));
+
+    let gAdv = 0,
+      gInt = 0,
+      gBeg = 0;
+
+    for (const mt of mutableTeams) {
+      const filled = mt.slots.filter((s) => s.userId).length;
+      const total = mt.slots.length;
+      let tAdv = 0,
+        tInt = 0,
+        tBeg = 0;
+      const tExp = teamExpTotal(mt);
+
+      for (const slot of mt.slots) {
+        if (slot.userId) {
+          const p = tagged.find((t) => t.userId === slot.userId);
+          const rank = p?.expRank || 0;
+          if (rank === 3) tAdv++;
+          else if (rank === 2) tInt++;
+          else if (rank === 1) tBeg++;
         }
       }
 
-      // Still nothing — create a new team
-      if (!match) {
-        const newTeam = createNewTeam();
-        const firstOpen = newTeam.slots.findIndex((s) => !s.userId);
-        if (firstOpen !== -1) {
-          match = { team: newTeam, slotIndex: firstOpen };
-        }
-      }
+      gAdv += tAdv;
+      gInt += tInt;
+      gBeg += tBeg;
 
-      if (match) {
-        match.team.slots[match.slotIndex].userId = p.userId;
-        assigned++;
-      }
+      const label = mt.isNew ? mt.name + " *" : mt.name;
+      console.log(
+        `  ${label.padEnd(20)} ${(filled + "/" + total).padStart(5)}  ${String(tAdv).padStart(4)} ${String(tInt).padStart(4)} ${String(tBeg).padStart(4)}  ${String(tExp).padStart(6)}`,
+      );
     }
 
-    // Persist changes
+    console.log("  " + "─".repeat(55));
+    console.log(
+      `  ${"TOTAL".padEnd(20)} ${String(assigned).padStart(5)}  ${String(gAdv).padStart(4)} ${String(gInt).padStart(4)} ${String(gBeg).padStart(4)}`,
+    );
+
+    const teamExpTotals = mutableTeams
+      .filter((t) => t.slots.some((s) => s.userId))
+      .map((t) => teamExpTotal(t));
+    const advCounts = mutableTeams.map(
+      (t) =>
+        t.slots.filter((s) => {
+          if (!s.userId) return false;
+          const p = tagged.find((tp) => tp.userId === s.userId);
+          return p?.expRank === 3;
+        }).length,
+    );
+    const filledTeams = mutableTeams.filter((t) =>
+      t.slots.some((s) => s.userId),
+    );
+
+    console.log("\n  BALANCE:");
+    console.log(
+      `    ExpTotal range: ${Math.min(...teamExpTotals)}-${Math.max(...teamExpTotals)} (spread: ${Math.max(...teamExpTotals) - Math.min(...teamExpTotals)})`,
+    );
+    console.log(
+      `    Adv/team range: ${Math.min(...advCounts)}-${Math.max(...advCounts)} (spread: ${Math.max(...advCounts) - Math.min(...advCounts)})`,
+    );
+    console.log(
+      `    Avg exp/team:   ${(teamExpTotals.reduce((a, b) => a + b, 0) / filledTeams.length).toFixed(1)}`,
+    );
+
+    console.log("\n══════════════════════════════════════════════");
+    console.log(
+      `  RESULT: ${assigned} assigned, ${teamsCreated} new teams, ${unassigned.length - assigned} unplaced`,
+    );
+    console.log("══════════════════════════════════════════════\n");
+
+    // --- Persist ---
     for (const mt of mutableTeams) {
       const slots: HackathonTeamSlot[] = mt.slots.map((s) => ({
         role: s.role,
@@ -230,16 +417,14 @@ export async function POST(
       }));
 
       if (mt.isNew) {
-        // Create the team in DB
         await createHackathonTeam({
           hackathonId: hackathon._id,
-          name: `Team ${teams.length + mutableTeams.filter((m) => m.isNew).indexOf(mt) + 1}`,
+          name: mt.name,
           description: "",
           slots,
           createdBy: authResult.auth.user.id,
         });
       } else {
-        // Update existing team
         await updateHackathonTeam(mt.id, { slots });
       }
     }

--- a/src/app/api/hackathons/[slug]/teams/reset-assignments/route.ts
+++ b/src/app/api/hackathons/[slug]/teams/reset-assignments/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/auth-helpers";
+import { getHackathonBySlug } from "@/lib/models/Hackathon";
+import {
+  getTeamsByHackathonId,
+  updateHackathonTeam,
+} from "@/lib/models/HackathonTeam";
+
+// POST /api/hackathons/[slug]/teams/reset-assignments
+// Clears all user assignments from team slots (admin only)
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { slug: string } },
+) {
+  try {
+    const authResult = await requireAdmin(request);
+    if (!authResult.ok) return authResult.response;
+
+    const hackathon = await getHackathonBySlug(params.slug);
+    if (!hackathon) {
+      return NextResponse.json(
+        { error: "Hackathon not found" },
+        { status: 404 },
+      );
+    }
+
+    const teams = await getTeamsByHackathonId(hackathon._id);
+
+    let clearedCount = 0;
+    for (const team of teams) {
+      const hadAssignments = team.slots.some((s) => s.userId);
+      if (!hadAssignments) continue;
+
+      const clearedSlots = team.slots.map((s) => ({
+        role: s.role,
+        userId: undefined,
+        required: s.required,
+      }));
+
+      clearedCount += team.slots.filter((s) => s.userId).length;
+      await updateHackathonTeam(team._id, { slots: clearedSlots });
+    }
+
+    return NextResponse.json({
+      message: `Reset ${clearedCount} assignments across ${teams.length} teams`,
+      cleared: clearedCount,
+      teamsAffected: teams.length,
+    });
+  } catch (error) {
+    console.error("Reset assignments error:", error);
+    return NextResponse.json(
+      { error: "Failed to reset assignments" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -117,6 +117,13 @@ body {
   .text-balance {
     text-wrap: balance;
   }
+  .scrollbar-none {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  .scrollbar-none::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 

--- a/src/app/hackathon/[slug]/admin/page.tsx
+++ b/src/app/hackathon/[slug]/admin/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "@/components/auth/AuthProvider";
 import TopNavBar from "@/components/nav/TopNavBar";
@@ -19,7 +19,6 @@ interface Participant {
   name: string;
   email?: string;
   involvement: string;
-  rolePreference?: string;
   skillBackground?: string | null;
   aiExperience?: string | null;
   avatarUrl?: string | null;
@@ -53,6 +52,16 @@ export default function HackathonAdminPage() {
   };
   const [editingParticipant, setEditingParticipant] =
     useState<Participant | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [sortField, setSortField] = useState<
+    | "name"
+    | "email"
+    | "skillBackground"
+    | "aiExperience"
+    | "involvement"
+    | "status"
+  >("name");
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
 
   const fetchData = useCallback(async () => {
     try {
@@ -120,6 +129,73 @@ export default function HackathonAdminPage() {
   const unassignedParticipants = participants.filter(
     (p) => !assignedUserIds.has(p.userId),
   );
+
+  // Filter and sort participants for the list view
+  const query = searchQuery.toLowerCase();
+  const filteredParticipants = participants
+    .filter((p) => {
+      if (!query) return true;
+      return (
+        p.name.toLowerCase().includes(query) ||
+        (p.email && p.email.toLowerCase().includes(query)) ||
+        (p.skillBackground &&
+          p.skillBackground.toLowerCase().includes(query)) ||
+        (p.aiExperience && p.aiExperience.toLowerCase().includes(query)) ||
+        p.involvement.toLowerCase().includes(query)
+      );
+    })
+    .sort((a, b) => {
+      let aVal = "";
+      let bVal = "";
+
+      switch (sortField) {
+        case "name":
+          aVal = a.name;
+          bVal = b.name;
+          break;
+        case "email":
+          aVal = a.email || "";
+          bVal = b.email || "";
+          break;
+        case "skillBackground":
+          aVal = a.skillBackground || "";
+          bVal = b.skillBackground || "";
+          break;
+        case "aiExperience":
+          aVal = a.aiExperience || "";
+          bVal = b.aiExperience || "";
+          break;
+        case "involvement":
+          aVal = a.involvement;
+          bVal = b.involvement;
+          break;
+        case "status":
+          aVal = assignedUserIds.has(a.userId) ? "assigned" : "unassigned";
+          bVal = assignedUserIds.has(b.userId) ? "assigned" : "unassigned";
+          break;
+      }
+
+      const cmp = aVal.localeCompare(bVal);
+      return sortDir === "asc" ? cmp : -cmp;
+    });
+
+  const handleSort = (field: typeof sortField) => {
+    if (sortField === field) {
+      setSortDir(sortDir === "asc" ? "desc" : "asc");
+    } else {
+      setSortField(field);
+      setSortDir("asc");
+    }
+  };
+
+  const SortIcon = ({ field }: { field: typeof sortField }) => {
+    if (sortField !== field) return null;
+    return (
+      <span className="ml-1 text-blue-400">
+        {sortDir === "asc" ? "↑" : "↓"}
+      </span>
+    );
+  };
 
   return (
     <div className="flex h-screen flex-col bg-black text-white">
@@ -231,105 +307,177 @@ export default function HackathonAdminPage() {
           )}
 
           {activeTab === "participants" && (
-            <div className="overflow-x-auto rounded-lg border border-gray-700">
-              <table className="w-full text-left text-sm">
-                <thead className="border-b border-gray-700 bg-gray-900">
-                  <tr>
-                    <th className="px-4 py-3 font-medium text-gray-300">
-                      Name
-                    </th>
-                    <th className="px-4 py-3 font-medium text-gray-300">
-                      Email
-                    </th>
-                    <th className="px-4 py-3 font-medium text-gray-300">
-                      Background
-                    </th>
-                    <th className="px-4 py-3 font-medium text-gray-300">
-                      Experience
-                    </th>
-                    <th className="px-4 py-3 font-medium text-gray-300">
-                      Role Pref
-                    </th>
-                    <th className="px-4 py-3 font-medium text-gray-300">
-                      Involvement
-                    </th>
-                    <th className="px-4 py-3 font-medium text-gray-300">
-                      Status
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-800">
-                  {participants.map((p) => (
-                    <tr
-                      key={p.userId}
-                      className="cursor-pointer transition-colors hover:bg-gray-800/50"
-                      onClick={() => setEditingParticipant(p)}
+            <div className="flex min-h-0 flex-1 flex-col">
+              {/* Search bar */}
+              <div className="mb-3 flex items-center gap-3">
+                <div className="relative flex-1">
+                  <svg
+                    className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                    />
+                  </svg>
+                  <input
+                    type="text"
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    placeholder="Search by name, email, background..."
+                    className="w-full rounded-lg border border-gray-700 bg-gray-900 py-2 pl-10 pr-4 text-sm text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+                  />
+                  {searchQuery && (
+                    <button
+                      onClick={() => setSearchQuery("")}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-300"
                     >
-                      <td
-                        className="max-w-[200px] truncate px-4 py-3 font-medium"
-                        title={p.name}
-                        aria-label={p.name}
+                      <svg
+                        className="h-4 w-4"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
                       >
-                        <span className="flex items-center gap-2">
-                          {p.name}
-                          <svg
-                            className="h-3 w-3 flex-shrink-0 text-gray-500"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              strokeWidth={2}
-                              d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
-                            />
-                          </svg>
-                        </span>
-                      </td>
-                      <td className="px-4 py-3 text-gray-400">{p.email}</td>
-                      <td className="px-4 py-3 text-gray-400">
-                        {p.skillBackground || "—"}
-                      </td>
-                      <td className="px-4 py-3 text-gray-400">
-                        {p.aiExperience || "—"}
-                      </td>
-                      <td className="px-4 py-3 text-gray-400">
-                        {p.rolePreference || "—"}
-                      </td>
-                      <td className="px-4 py-3">
-                        <span
-                          className={`rounded-full px-2 py-0.5 text-xs capitalize ${
-                            p.involvement === "mentor"
-                              ? "bg-purple-600/20 text-purple-400"
-                              : p.involvement === "volunteer"
-                                ? "bg-blue-600/20 text-blue-400"
-                                : "bg-gray-600/20 text-gray-400"
-                          }`}
-                        >
-                          {p.involvement}
-                        </span>
-                      </td>
-                      <td className="px-4 py-3">
-                        {assignedUserIds.has(p.userId) ? (
-                          <span className="rounded-full bg-green-600/20 px-2 py-0.5 text-xs text-green-400">
-                            Assigned
-                          </span>
-                        ) : (
-                          <span className="rounded-full bg-yellow-600/20 px-2 py-0.5 text-xs text-yellow-400">
-                            Unassigned
-                          </span>
-                        )}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-              {participants.length === 0 && (
-                <div className="p-8 text-center text-gray-400">
-                  No participants registered yet.
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M6 18L18 6M6 6l12 12"
+                        />
+                      </svg>
+                    </button>
+                  )}
                 </div>
-              )}
+                <span className="flex-shrink-0 text-xs text-gray-500">
+                  {filteredParticipants.length} of {participants.length}
+                </span>
+              </div>
+
+              {/* Table */}
+              <div className="min-h-0 flex-1 overflow-auto rounded-lg border border-gray-700">
+                <table className="w-full text-left text-sm">
+                  <thead className="sticky top-0 border-b border-gray-700 bg-gray-900">
+                    <tr>
+                      <th
+                        onClick={() => handleSort("name")}
+                        className="cursor-pointer px-4 py-3 font-medium text-gray-300 hover:text-white"
+                      >
+                        Name
+                        <SortIcon field="name" />
+                      </th>
+                      <th
+                        onClick={() => handleSort("email")}
+                        className="cursor-pointer px-4 py-3 font-medium text-gray-300 hover:text-white"
+                      >
+                        Email
+                        <SortIcon field="email" />
+                      </th>
+                      <th
+                        onClick={() => handleSort("skillBackground")}
+                        className="cursor-pointer px-4 py-3 font-medium text-gray-300 hover:text-white"
+                      >
+                        Background
+                        <SortIcon field="skillBackground" />
+                      </th>
+                      <th
+                        onClick={() => handleSort("aiExperience")}
+                        className="cursor-pointer px-4 py-3 font-medium text-gray-300 hover:text-white"
+                      >
+                        Experience
+                        <SortIcon field="aiExperience" />
+                      </th>
+                      <th
+                        onClick={() => handleSort("involvement")}
+                        className="cursor-pointer px-4 py-3 font-medium text-gray-300 hover:text-white"
+                      >
+                        Involvement
+                        <SortIcon field="involvement" />
+                      </th>
+                      <th
+                        onClick={() => handleSort("status")}
+                        className="cursor-pointer px-4 py-3 font-medium text-gray-300 hover:text-white"
+                      >
+                        Status
+                        <SortIcon field="status" />
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-800">
+                    {filteredParticipants.map((p) => (
+                      <tr
+                        key={p.userId}
+                        className="cursor-pointer transition-colors hover:bg-gray-800/50"
+                        onClick={() => setEditingParticipant(p)}
+                      >
+                        <td
+                          className="max-w-[200px] truncate px-4 py-3 font-medium"
+                          title={p.name}
+                          aria-label={p.name}
+                        >
+                          <span className="flex items-center gap-2">
+                            {p.name}
+                            <svg
+                              className="h-3 w-3 flex-shrink-0 text-gray-500"
+                              fill="none"
+                              stroke="currentColor"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={2}
+                                d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
+                              />
+                            </svg>
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 text-gray-400">{p.email}</td>
+                        <td className="px-4 py-3 text-gray-400">
+                          {p.skillBackground || "—"}
+                        </td>
+                        <td className="px-4 py-3 text-gray-400">
+                          {p.aiExperience || "—"}
+                        </td>
+                        <td className="px-4 py-3">
+                          <span
+                            className={`rounded-full px-2 py-0.5 text-xs capitalize ${
+                              p.involvement === "mentor"
+                                ? "bg-purple-600/20 text-purple-400"
+                                : p.involvement === "volunteer"
+                                  ? "bg-blue-600/20 text-blue-400"
+                                  : "bg-gray-600/20 text-gray-400"
+                            }`}
+                          >
+                            {p.involvement}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3">
+                          {assignedUserIds.has(p.userId) ? (
+                            <span className="rounded-full bg-green-600/20 px-2 py-0.5 text-xs text-green-400">
+                              Assigned
+                            </span>
+                          ) : (
+                            <span className="rounded-full bg-yellow-600/20 px-2 py-0.5 text-xs text-yellow-400">
+                              Unassigned
+                            </span>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+                {filteredParticipants.length === 0 && (
+                  <div className="p-8 text-center text-gray-400">
+                    {participants.length === 0
+                      ? "No participants registered yet."
+                      : "No participants match your search."}
+                  </div>
+                )}
+              </div>
             </div>
           )}
         </div>

--- a/src/app/hackathon/[slug]/page.tsx
+++ b/src/app/hackathon/[slug]/page.tsx
@@ -85,7 +85,6 @@ export default function HackathonLandingPage() {
           hackathonId: hackathon._id,
           userId: user.id,
           involvement: myReg.involvement,
-          rolePreference: myReg.rolePreference,
           registeredAt: new Date(myReg.registeredAt),
         });
       }

--- a/src/components/hackathon/AdminKanbanBoard.tsx
+++ b/src/components/hackathon/AdminKanbanBoard.tsx
@@ -33,7 +33,6 @@ interface Participant {
   name: string;
   email?: string;
   involvement: string;
-  rolePreference?: string;
   skillBackground?: string | null;
   aiExperience?: string | null;
 }
@@ -81,9 +80,8 @@ function DraggableCard({
     );
   }
 
-  const prefAbbrev = participant.rolePreference
-    ? ROLE_ABBREV[participant.rolePreference] ||
-      participant.rolePreference.slice(0, 2).toUpperCase()
+  const skillRole = participant.skillBackground
+    ? SKILL_ABBREV[participant.skillBackground] || null
     : null;
 
   return (
@@ -97,12 +95,12 @@ function DraggableCard({
           : "border-blue-500/30 bg-blue-500/5 hover:border-blue-500/50"
       }`}
     >
-      {prefAbbrev ? (
+      {skillRole ? (
         <span
           className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-blue-500/20 text-[9px] font-bold text-blue-400"
-          title={`Wants: ${participant.rolePreference}`}
+          title={`Background: ${participant.skillBackground}`}
         >
-          {prefAbbrev}
+          {skillRole}
         </span>
       ) : (
         <span className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full border border-gray-500 text-[9px] text-gray-500">
@@ -133,6 +131,16 @@ const ROLE_ABBREV: Record<string, string> = {
   "Backend Engineer": "BE",
   "Frontend Developer": "FE",
   Flex: "FX",
+};
+
+const SKILL_ABBREV: Record<string, string> = {
+  "Frontend development": "FE",
+  "Backend development": "BE",
+  "Data / Machine Learning / AI": "AI",
+  "Design / UX": "UX",
+  "Product Management": "PM",
+  "DevOps / Infrastructure": "BE",
+  "Non-technical (learning AI tools)": "FX",
 };
 
 // Droppable slot inside a team column
@@ -581,7 +589,7 @@ function SortableTeamColumn({
       </div>
 
       {/* Slots */}
-      <div className="min-h-0 flex-1 space-y-2 overflow-y-auto scrollbar-none">
+      <div className="scrollbar-none min-h-0 flex-1 space-y-2 overflow-y-auto">
         {team.slots.map((slot, idx) => (
           <DroppableSlot
             key={`${slot.role}-${idx}`}
@@ -960,30 +968,72 @@ export default function AdminKanbanBoard({
                 ({unassignedParticipants.length})
               </span>
             </h3>
-            {unassignedParticipants.length > 0 && (
+            <div className="flex gap-1">
+              {unassignedParticipants.length > 0 && (
+                <button
+                  onClick={() => {
+                    if (processing) return;
+                    showConfirm({
+                      title: "Auto-Assign Participants",
+                      message: `Auto-assign ${unassignedParticipants.length} participants to teams based on their role preferences?`,
+                      onConfirm: async () => {
+                        setConfirmState((prev) => ({ ...prev, open: false }));
+                        setProcessing(true);
+                        try {
+                          const res = await fetch(
+                            `/api/hackathons/${slug}/teams/auto-assign`,
+                            { method: "POST" },
+                          );
+                          const data = await res.json();
+                          if (res.ok) {
+                            toast(
+                              `${data.assigned} assigned${data.teamsCreated ? `, ${data.teamsCreated} new team(s) created` : ""}`,
+                              "success",
+                            );
+                            onRefresh();
+                          } else {
+                            toast(data.error || "Auto-assign failed", "error");
+                          }
+                        } catch {
+                          toast("Something went wrong", "error");
+                        } finally {
+                          setProcessing(false);
+                        }
+                      },
+                    });
+                  }}
+                  disabled={processing}
+                  className="rounded bg-green-600 px-2 py-1 text-[10px] font-medium transition-colors hover:bg-green-700 disabled:opacity-50"
+                  title="Auto-assign all unassigned participants to teams based on their role preferences"
+                >
+                  &#9889; Auto
+                </button>
+              )}
               <button
                 onClick={() => {
                   if (processing) return;
                   showConfirm({
-                    title: "Auto-Assign Participants",
-                    message: `Auto-assign ${unassignedParticipants.length} participants to teams based on their role preferences?`,
+                    title: "Reset All Assignments",
+                    message:
+                      "Remove all participants from their teams? They will be moved back to unassigned.",
+                    variant: "danger",
                     onConfirm: async () => {
                       setConfirmState((prev) => ({ ...prev, open: false }));
                       setProcessing(true);
                       try {
                         const res = await fetch(
-                          `/api/hackathons/${slug}/teams/auto-assign`,
+                          `/api/hackathons/${slug}/teams/reset-assignments`,
                           { method: "POST" },
                         );
                         const data = await res.json();
                         if (res.ok) {
                           toast(
-                            `${data.assigned} assigned${data.teamsCreated ? `, ${data.teamsCreated} new team(s) created` : ""}`,
+                            `${data.cleared} assignments cleared`,
                             "success",
                           );
                           onRefresh();
                         } else {
-                          toast(data.error || "Auto-assign failed", "error");
+                          toast(data.error || "Reset failed", "error");
                         }
                       } catch {
                         toast("Something went wrong", "error");
@@ -994,19 +1044,19 @@ export default function AdminKanbanBoard({
                   });
                 }}
                 disabled={processing}
-                className="rounded bg-green-600 px-2 py-1 text-[10px] font-medium transition-colors hover:bg-green-700 disabled:opacity-50"
-                title="Auto-assign all unassigned participants to teams based on their role preferences"
+                className="rounded bg-gray-700 px-2 py-1 text-[10px] font-medium text-gray-300 transition-colors hover:bg-red-600/20 hover:text-red-400 disabled:opacity-50"
+                title="Remove all participants from teams"
               >
-                &#9889; Auto
+                Reset
               </button>
-            )}
+            </div>
           </div>
           {isOverUnassigned && activeDragData?.sourceTeamId && (
             <div className="mb-2 rounded-lg border border-dashed border-yellow-500 bg-yellow-500/10 px-3 py-2 text-center text-xs text-yellow-400">
               Drop to unassign
             </div>
           )}
-          <div className="min-h-0 flex-1 space-y-2 overflow-y-auto scrollbar-none">
+          <div className="scrollbar-none min-h-0 flex-1 space-y-2 overflow-y-auto">
             {unassignedParticipants
               .filter((p) => p.userId !== pendingMoveUserId)
               .map((p) => (

--- a/src/components/hackathon/AdminKanbanBoard.tsx
+++ b/src/components/hackathon/AdminKanbanBoard.tsx
@@ -366,7 +366,7 @@ function SortableTeamColumn({
         setDropRef(node);
       }}
       style={style}
-      className={`flex w-[85vw] flex-shrink-0 flex-col rounded-xl border p-4 transition-colors sm:w-72 ${
+      className={`flex min-h-0 w-[85vw] flex-shrink-0 flex-col rounded-xl border p-4 transition-colors sm:w-72 ${
         isOver ? "border-blue-500 bg-blue-500/5" : "border-gray-700 bg-gray-900"
       }`}
     >
@@ -581,7 +581,7 @@ function SortableTeamColumn({
       </div>
 
       {/* Slots */}
-      <div className="space-y-2">
+      <div className="min-h-0 flex-1 space-y-2 overflow-y-auto scrollbar-none">
         {team.slots.map((slot, idx) => (
           <DroppableSlot
             key={`${slot.role}-${idx}`}
@@ -802,6 +802,7 @@ export default function AdminKanbanBoard({
     const overData = over.data.current as {
       teamId?: string;
       role?: string;
+      index?: number;
       zone?: string;
     };
 
@@ -815,25 +816,32 @@ export default function AdminKanbanBoard({
       return;
     }
 
-    // Determine target team and role
+    // Determine target team, role, and slot index
     let targetTeamId: string | undefined;
-    let targetRole: string | undefined;
+    let targetSlotIndex: number | undefined;
 
-    if (overData?.role) {
+    if (overData?.role != null && overData.index != null) {
       targetTeamId = overData.teamId;
-      targetRole = overData.role;
+      targetSlotIndex = overData.index;
     } else if (over.id.toString().startsWith("team-")) {
       targetTeamId = over.id.toString().replace("team-", "");
       const team = teams.find((t) => t._id === targetTeamId);
-      const openSlot = team?.slots.find((s) => !s.userId);
-      if (!openSlot) return;
-      targetRole = openSlot.role;
+      const firstOpenIndex = team?.slots.findIndex((s) => !s.userId);
+      if (firstOpenIndex == null || firstOpenIndex === -1) return;
+      targetSlotIndex = firstOpenIndex;
     }
 
-    if (!targetTeamId || !targetRole) return;
+    if (!targetTeamId || targetSlotIndex == null) return;
 
-    // Same team, same role — no-op
-    if (sourceTeamId === targetTeamId && dragData.sourceRole === targetRole)
+    // Find the source slot index for same-team no-op check
+    const sourceSlotIndex = sourceTeamId
+      ? teams
+          .find((t) => t._id === sourceTeamId)
+          ?.slots.findIndex((s) => s.userId === participant.userId)
+      : undefined;
+
+    // Same team, same slot — no-op
+    if (sourceTeamId === targetTeamId && sourceSlotIndex === targetSlotIndex)
       return;
 
     // Hide the card during the move to prevent snap-back visual
@@ -844,17 +852,13 @@ export default function AdminKanbanBoard({
         // Moving within the same team (role swap)
         const team = teams.find((t) => t._id === sourceTeamId);
         if (team) {
-          let removed = false;
-          let assigned = false;
-          const newSlots = team.slots.map((s) => {
+          const newSlots = team.slots.map((s, i) => {
             // Remove from old slot
-            if (s.userId === participant.userId && !removed) {
-              removed = true;
+            if (i === sourceSlotIndex) {
               return { ...s, userId: undefined, userName: null };
             }
-            // Assign to new slot
-            if (s.role === targetRole && !s.userId && !assigned) {
-              assigned = true;
+            // Assign to target slot
+            if (i === targetSlotIndex) {
               return {
                 ...s,
                 userId: participant.userId,
@@ -880,13 +884,11 @@ export default function AdminKanbanBoard({
           }
         }
 
-        // Assign to target team
+        // Assign to target team by index
         const targetTeam = teams.find((t) => t._id === targetTeamId);
         if (targetTeam) {
-          let filled = false;
-          const targetSlots = targetTeam.slots.map((s) => {
-            if (s.role === targetRole && !s.userId && !filled) {
-              filled = true;
+          const targetSlots = targetTeam.slots.map((s, i) => {
+            if (i === targetSlotIndex && !s.userId) {
               return {
                 ...s,
                 userId: participant.userId,
@@ -1004,7 +1006,7 @@ export default function AdminKanbanBoard({
               Drop to unassign
             </div>
           )}
-          <div className="min-h-0 flex-1 space-y-2 overflow-y-auto">
+          <div className="min-h-0 flex-1 space-y-2 overflow-y-auto scrollbar-none">
             {unassignedParticipants
               .filter((p) => p.userId !== pendingMoveUserId)
               .map((p) => (

--- a/src/components/hackathon/CreateTeamModal.tsx
+++ b/src/components/hackathon/CreateTeamModal.tsx
@@ -17,16 +17,32 @@ export default function CreateTeamModal({
   onClose,
   onCreated,
 }: Props) {
+  const [mode, setMode] = useState<"single" | "bulk">("single");
+
+  // Single mode state
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [selectedRoles, setSelectedRoles] = useState<
     { role: HackathonRole; required: boolean }[]
-  >(
-    hackathon.roles.slice(0, hackathon.maxTeamSize).map((role) => ({
+  >(() => {
+    const base = hackathon.roles.map((role) => ({
       role,
       required: hackathon.requiredRoles.includes(role),
-    })),
-  );
+    }));
+    const extra = Math.max(0, hackathon.maxTeamSize - base.length);
+    return [
+      ...base,
+      ...Array.from({ length: extra }, () => ({
+        role: "Flex" as HackathonRole,
+        required: false,
+      })),
+    ].slice(0, hackathon.maxTeamSize);
+  });
+
+  // Bulk mode state
+  const [bulkCount, setBulkCount] = useState(5);
+  const [bulkPrefix, setBulkPrefix] = useState("Team");
+
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
@@ -42,7 +58,7 @@ export default function CreateTeamModal({
     }
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSingleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!name.trim()) return;
 
@@ -77,6 +93,60 @@ export default function CreateTeamModal({
     }
   };
 
+  const handleBulkSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (bulkCount < 1) return;
+
+    setLoading(true);
+    setError("");
+
+    const baseSlots = hackathon.roles.map((role) => ({
+      role,
+      required: hackathon.requiredRoles.includes(role),
+    }));
+    // If maxTeamSize exceeds the number of defined roles, pad with Flex slots
+    const extraSlots = Math.max(0, hackathon.maxTeamSize - baseSlots.length);
+    const defaultSlots = [
+      ...baseSlots,
+      ...Array.from({ length: extraSlots }, () => ({
+        role: "Flex" as HackathonRole,
+        required: false,
+      })),
+    ].slice(0, hackathon.maxTeamSize);
+
+    try {
+      let created = 0;
+      for (let i = 1; i <= bulkCount; i++) {
+        const teamName = `${bulkPrefix.trim()} ${i}`;
+        const res = await fetch(`/api/hackathons/${slug}/teams`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: teamName,
+            description: "",
+            slots: defaultSlots,
+          }),
+        });
+
+        if (res.ok) {
+          created++;
+        } else {
+          const data = await res.json();
+          // If duplicate name, skip and continue
+          if (res.status === 409) continue;
+          setError(data.error || `Failed at team ${i}`);
+          break;
+        }
+      }
+
+      if (created > 0) onCreated();
+    } catch {
+      setError("Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
     <Dialog open={true} onClose={onClose} className="relative z-50">
       <div className="fixed inset-0 bg-black/70" aria-hidden="true" />
@@ -104,89 +174,209 @@ export default function CreateTeamModal({
             </button>
           </div>
 
-          <form onSubmit={handleSubmit} className="space-y-5">
-            <div>
-              <label className="mb-2 block text-sm font-medium text-gray-300">
-                Team Name
-              </label>
-              <input
-                type="text"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder="e.g. Team Alpha"
-                className="w-full rounded-lg border border-gray-600 bg-gray-800 px-4 py-2.5 text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
-                required
-              />
-            </div>
+          {/* Mode tabs */}
+          <div className="mb-5 flex gap-1 rounded-lg border border-gray-700 bg-gray-800 p-1">
+            <button
+              type="button"
+              onClick={() => {
+                setMode("single");
+                setError("");
+              }}
+              className={`flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+                mode === "single"
+                  ? "bg-gray-700 text-white"
+                  : "text-gray-400 hover:text-white"
+              }`}
+            >
+              Single
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setMode("bulk");
+                setError("");
+              }}
+              className={`flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+                mode === "bulk"
+                  ? "bg-gray-700 text-white"
+                  : "text-gray-400 hover:text-white"
+              }`}
+            >
+              Bulk Create
+            </button>
+          </div>
 
-            <div>
-              <label className="mb-2 block text-sm font-medium text-gray-300">
-                Description (optional)
-              </label>
-              <input
-                type="text"
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                placeholder="e.g. Building an AI-powered code reviewer"
-                className="w-full rounded-lg border border-gray-600 bg-gray-800 px-4 py-2.5 text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
-              />
-            </div>
-
-            <div>
-              <label className="mb-2 block text-sm font-medium text-gray-300">
-                Role Slots ({selectedRoles.length}/{hackathon.maxTeamSize})
-              </label>
-              <div className="flex flex-wrap gap-2">
-                {hackathon.roles.map((role) => {
-                  const selected = selectedRoles.some((r) => r.role === role);
-                  const isRequired = hackathon.requiredRoles.includes(role);
-                  return (
-                    <button
-                      key={role}
-                      type="button"
-                      onClick={() => toggleRole(role)}
-                      className={`rounded-lg border px-3 py-1.5 text-sm transition-colors ${
-                        selected
-                          ? isRequired
-                            ? "border-blue-500 bg-blue-500/20 text-blue-400"
-                            : "border-gray-500 bg-gray-700 text-white"
-                          : "border-gray-600 bg-gray-800 text-gray-400 hover:border-gray-500"
-                      }`}
-                    >
-                      {role}
-                      {isRequired && selected && " *"}
-                    </button>
-                  );
-                })}
+          {mode === "single" ? (
+            <form onSubmit={handleSingleSubmit} className="space-y-5">
+              <div>
+                <label className="mb-2 block text-sm font-medium text-gray-300">
+                  Team Name
+                </label>
+                <input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="e.g. Team Alpha"
+                  className="w-full rounded-lg border border-gray-600 bg-gray-800 px-4 py-2.5 text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+                  required
+                />
               </div>
-              <p className="mt-1 text-xs text-gray-500">
-                * = required role. Click to toggle slots.
-              </p>
-            </div>
 
-            {error && (
-              <div className="rounded-lg bg-red-500/10 px-4 py-3 text-sm text-red-400">
-                {error}
+              <div>
+                <label className="mb-2 block text-sm font-medium text-gray-300">
+                  Description (optional)
+                </label>
+                <input
+                  type="text"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="e.g. Building an AI-powered code reviewer"
+                  className="w-full rounded-lg border border-gray-600 bg-gray-800 px-4 py-2.5 text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+                />
               </div>
-            )}
 
-            <div className="flex gap-3 pt-2">
-              <button
-                type="button"
-                onClick={onClose}
-                className="flex-1 rounded-lg border border-gray-600 px-4 py-2.5 font-medium text-gray-300 transition-colors hover:bg-gray-800"
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                disabled={loading || !name.trim() || selectedRoles.length === 0}
-                className="flex-1 rounded-lg bg-blue-600 px-4 py-2.5 font-medium transition-colors hover:bg-blue-700 disabled:opacity-50"
-              >
-                {loading ? "Creating..." : "Create Team"}
-              </button>
-            </div>
-          </form>
+              <div>
+                <label className="mb-2 block text-sm font-medium text-gray-300">
+                  Role Slots ({selectedRoles.length}/{hackathon.maxTeamSize})
+                </label>
+                <div className="flex flex-wrap gap-2">
+                  {hackathon.roles.map((role) => {
+                    const selected = selectedRoles.some((r) => r.role === role);
+                    const isRequired = hackathon.requiredRoles.includes(role);
+                    return (
+                      <button
+                        key={role}
+                        type="button"
+                        onClick={() => toggleRole(role)}
+                        className={`rounded-lg border px-3 py-1.5 text-sm transition-colors ${
+                          selected
+                            ? isRequired
+                              ? "border-blue-500 bg-blue-500/20 text-blue-400"
+                              : "border-gray-500 bg-gray-700 text-white"
+                            : "border-gray-600 bg-gray-800 text-gray-400 hover:border-gray-500"
+                        }`}
+                      >
+                        {role}
+                        {isRequired && selected && " *"}
+                      </button>
+                    );
+                  })}
+                </div>
+                <p className="mt-1 text-xs text-gray-500">
+                  * = required role. Click to toggle slots.
+                </p>
+              </div>
+
+              {error && (
+                <div className="rounded-lg bg-red-500/10 px-4 py-3 text-sm text-red-400">
+                  {error}
+                </div>
+              )}
+
+              <div className="flex gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="flex-1 rounded-lg border border-gray-600 px-4 py-2.5 font-medium text-gray-300 transition-colors hover:bg-gray-800"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={
+                    loading || !name.trim() || selectedRoles.length === 0
+                  }
+                  className="flex-1 rounded-lg bg-blue-600 px-4 py-2.5 font-medium transition-colors hover:bg-blue-700 disabled:opacity-50"
+                >
+                  {loading ? "Creating..." : "Create Team"}
+                </button>
+              </div>
+            </form>
+          ) : (
+            <form onSubmit={handleBulkSubmit} className="space-y-5">
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="mb-2 block text-sm font-medium text-gray-300">
+                    Number of Teams
+                  </label>
+                  <input
+                    type="number"
+                    value={bulkCount}
+                    onChange={(e) =>
+                      setBulkCount(
+                        Math.max(
+                          1,
+                          Math.min(50, parseInt(e.target.value) || 1),
+                        ),
+                      )
+                    }
+                    min={1}
+                    max={50}
+                    className="w-full rounded-lg border border-gray-600 bg-gray-800 px-4 py-2.5 text-white focus:border-blue-500 focus:outline-none"
+                  />
+                </div>
+                <div>
+                  <label className="mb-2 block text-sm font-medium text-gray-300">
+                    Name Prefix
+                  </label>
+                  <input
+                    type="text"
+                    value={bulkPrefix}
+                    onChange={(e) => setBulkPrefix(e.target.value)}
+                    placeholder="Team"
+                    className="w-full rounded-lg border border-gray-600 bg-gray-800 px-4 py-2.5 text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+                  />
+                </div>
+              </div>
+
+              <div className="rounded-lg border border-gray-700 bg-gray-800/50 px-4 py-3">
+                <div className="mb-1 text-sm text-gray-300">Preview</div>
+                <div className="text-xs text-gray-400">
+                  {Array.from({ length: Math.min(bulkCount, 3) }, (_, i) => (
+                    <span key={i}>
+                      {bulkPrefix.trim()} {i + 1}
+                      {i < Math.min(bulkCount, 3) - 1 ? ", " : ""}
+                    </span>
+                  ))}
+                  {bulkCount > 3 && (
+                    <span>
+                      {" "}
+                      ... {bulkPrefix.trim()} {bulkCount}
+                    </span>
+                  )}
+                </div>
+                <div className="mt-1 text-xs text-gray-500">
+                  Each team gets {hackathon.roles.length} role slots (
+                  {hackathon.roles.join(", ")})
+                </div>
+              </div>
+
+              {error && (
+                <div className="rounded-lg bg-red-500/10 px-4 py-3 text-sm text-red-400">
+                  {error}
+                </div>
+              )}
+
+              <div className="flex gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="flex-1 rounded-lg border border-gray-600 px-4 py-2.5 font-medium text-gray-300 transition-colors hover:bg-gray-800"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={loading || bulkCount < 1 || !bulkPrefix.trim()}
+                  className="flex-1 rounded-lg bg-blue-600 px-4 py-2.5 font-medium transition-colors hover:bg-blue-700 disabled:opacity-50"
+                >
+                  {loading
+                    ? "Creating..."
+                    : `Create ${bulkCount} Team${bulkCount !== 1 ? "s" : ""}`}
+                </button>
+              </div>
+            </form>
+          )}
         </DialogPanel>
       </div>
     </Dialog>

--- a/src/components/hackathon/EditParticipantModal.tsx
+++ b/src/components/hackathon/EditParticipantModal.tsx
@@ -2,19 +2,13 @@
 
 import { useState } from "react";
 import { Dialog, DialogPanel, DialogTitle } from "@headlessui/react";
-import {
-  SKILL_BACKGROUNDS,
-  AI_EXPERIENCE_LEVELS,
-  HACKATHON_ROLES,
-} from "@/types";
-import type { HackathonRole, SkillBackground, AiExperience } from "@/types";
+import { SKILL_BACKGROUNDS, AI_EXPERIENCE_LEVELS } from "@/types";
 
 interface Participant {
   userId: string;
   name: string;
   email?: string;
   involvement: string;
-  rolePreference?: string;
   skillBackground?: string | null;
   aiExperience?: string | null;
 }
@@ -41,9 +35,6 @@ export default function EditParticipantModal({
   const [aiExperience, setAiExperience] = useState(
     participant.aiExperience || "",
   );
-  const [rolePreference, setRolePreference] = useState(
-    participant.rolePreference || "",
-  );
   const [involvement, setInvolvement] = useState(participant.involvement);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
@@ -61,7 +52,6 @@ export default function EditParticipantModal({
         name: name.trim(),
         skillBackground,
         aiExperience,
-        rolePreference: rolePreference || null,
         involvement,
       };
 
@@ -193,24 +183,6 @@ export default function EditParticipantModal({
                 {AI_EXPERIENCE_LEVELS.map((level) => (
                   <option key={level} value={level}>
                     {level}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            <div>
-              <label className="mb-1 block text-sm font-medium text-gray-300">
-                Role Preference
-              </label>
-              <select
-                value={rolePreference}
-                onChange={(e) => setRolePreference(e.target.value)}
-                className="w-full rounded-lg border border-gray-600 bg-gray-800 px-4 py-2.5 text-white focus:border-blue-500 focus:outline-none"
-              >
-                <option value="">No preference</option>
-                {HACKATHON_ROLES.map((role) => (
-                  <option key={role} value={role}>
-                    {role}
                   </option>
                 ))}
               </select>

--- a/src/components/hackathon/HackathonRegistrationForm.tsx
+++ b/src/components/hackathon/HackathonRegistrationForm.tsx
@@ -2,15 +2,10 @@
 
 import { useState } from "react";
 import { Dialog, DialogPanel, DialogTitle } from "@headlessui/react";
-import {
-  SKILL_BACKGROUNDS,
-  AI_EXPERIENCE_LEVELS,
-  HACKATHON_ROLES,
-} from "@/types";
+import { SKILL_BACKGROUNDS, AI_EXPERIENCE_LEVELS } from "@/types";
 import type {
   Hackathon,
   HackathonInvolvement,
-  HackathonRole,
   SkillBackground,
   AiExperience,
 } from "@/types";
@@ -28,7 +23,6 @@ export default function HackathonRegistrationForm({
 }: Props) {
   const [involvement, setInvolvement] =
     useState<HackathonInvolvement>("participant");
-  const [rolePreference, setRolePreference] = useState<HackathonRole | "">("");
   const [skillBackground, setSkillBackground] = useState<SkillBackground | "">(
     "",
   );
@@ -47,7 +41,6 @@ export default function HackathonRegistrationForm({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           involvement,
-          rolePreference,
           skillBackground,
           aiExperience,
         }),
@@ -161,28 +154,6 @@ export default function HackathonRegistrationForm({
                 {AI_EXPERIENCE_LEVELS.map((level) => (
                   <option key={level} value={level}>
                     {level}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            {/* Role Preference */}
-            <div>
-              <label className="mb-2 block text-sm font-medium text-gray-300">
-                Preferred role
-              </label>
-              <select
-                value={rolePreference}
-                onChange={(e) =>
-                  setRolePreference(e.target.value as HackathonRole)
-                }
-                required
-                className="w-full rounded-lg border border-gray-600 bg-gray-800 px-4 py-2.5 text-white focus:border-blue-500 focus:outline-none"
-              >
-                <option value="">Select your preferred role</option>
-                {hackathon.roles.map((role) => (
-                  <option key={role} value={role}>
-                    {role}
                   </option>
                 ))}
               </select>


### PR DESCRIPTION
Hackathon Admin Tooling & Auto-Assign Algorithm

Overview

Improvements to the hackathon admin experience — better team assignment algorithms, streamlined registration, and new admin tools for managing participants and teams at scale.

  Auto-Assign Algorithm
  - Experience-balanced distribution: Processes participants by experience tier (Advanced → Intermediate → Beginner), placing each on the team with the lowest total
  experience score. Every team ends up with nearly identical experience composition (spread of 1 in testing with 200 participants across 20 teams).
  - Pre-creates teams: Calculates required team count upfront so the balancer has the full pool to work with, preventing the "first teams get all the talent" problem.
  - Skill-to-role mapping: Derives team role from skillBackground instead of self-reported rolePreference, producing more accurate and balanced placements.
  - Batch profile fetching: Replaced N+1 sequential DB queries with a single batch fetch.
  - Flex slot padding: Teams auto-fill with Flex slots when maxTeamSize exceeds defined roles.

  Registration Simplification
  - Removed rolePreference from the registration form — role assignment is now fully derived from skillBackground via the auto-assign algorithm. Reduces user friction (one
  fewer field) and eliminates the misleading "preferred role" that couldn't be guaranteed.
  - All remaining registration fields (involvement, skillBackground, aiExperience) are now required with both client and server validation.

  Admin Tools
  - Create Hackathon UI: Admins see a "Create Hackathon" button and full form when no active hackathon exists, plus a list of all hackathons (past and present) with status
  badges and quick links to view/admin.
  - Bulk Team Create: New "Bulk Create" tab in the Create Team modal — enter a count and naming prefix to create N teams with default role slots.
  - Reset Assignments: One-click button to clear all team assignments, moving everyone back to unassigned.
  - Teams Lock Toggle: Admins can lock/unlock team join/leave from the Settings panel.
  - Search & Sort: Participants list now has full-text search (name, email, background, experience, involvement) and clickable sortable column headers with direction
  indicators.

  Bug Fixes
  - Custom role duplication: Fixed drag-and-drop assignment using slot index instead of role name — prevents users from being duplicated across identically-named custom
  role slots.
  - Kanban column scrolling: Team columns now scroll their contents independently with hidden scrollbars.
  - hackathonId type mismatch: Fixed ObjectId vs string inconsistency in seed scripts.