### PR TITLE
Add member directory emails and team contact features

### DIFF
--- a/src/app/api/hackathons/[slug]/teams/route.ts
+++ b/src/app/api/hackathons/[slug]/teams/route.ts
@@ -7,6 +7,8 @@ import {
   createHackathonTeam,
   getTeamsByHackathonId,
 } from "@/lib/models/HackathonTeam";
+import { getProfilesByUserIds } from "@/lib/models/Profile";
+import { getAuthFromRequest } from "@/lib/jwt";
 import type { HackathonTeamSlot } from "@/types";
 
 // GET /api/hackathons/[slug]/teams - List all teams
@@ -25,7 +27,7 @@ export async function GET(
 
     const teams = await getTeamsByHackathonId(hackathon._id);
 
-    // Batch-fetch all user names for filled slots
+    // Batch-fetch all user names and profiles for filled slots
     const allUserIds = Array.from(
       new Set(
         teams.flatMap((t) =>
@@ -34,16 +36,40 @@ export async function GET(
       ),
     );
     const userMap = await getUsersByIds(allUserIds);
+    const profileMap = await getProfilesByUserIds(allUserIds);
 
-    const enrichedTeams = teams.map((team) => ({
-      ...team,
-      slots: team.slots.map((slot) => ({
-        ...slot,
-        userName: slot.userId
-          ? userMap.get(slot.userId)?.name || "Unknown"
-          : null,
-      })),
-    }));
+    // Determine current user's team for email visibility
+    const auth = getAuthFromRequest(request);
+    const currentUserId = auth?.user?.id;
+    const isAdmin = currentUserId
+      ? userMap.get(currentUserId)?.isAdmin === true
+      : false;
+
+    // Find which team the current user is on
+    const currentUserTeamId = currentUserId
+      ? teams.find((t) => t.slots.some((s) => s.userId === currentUserId))?._id
+      : undefined;
+
+    const enrichedTeams = teams.map((team) => {
+      const isSameTeam = currentUserTeamId === team._id;
+
+      return {
+        ...team,
+        slots: team.slots.map((slot) => {
+          const user = slot.userId ? userMap.get(slot.userId) : undefined;
+          const profile = slot.userId ? profileMap.get(slot.userId) : undefined;
+          const showEmail = !!(slot.userId && user && (isAdmin || isSameTeam));
+
+          return {
+            ...slot,
+            userName: user?.name || (slot.userId ? "Unknown" : null),
+            avatarUrl: profile?.avatarUrl || null,
+            isPublic: profile?.isPublic || false,
+            email: showEmail ? user!.email : null,
+          };
+        }),
+      };
+    });
 
     return NextResponse.json({ teams: enrichedTeams });
   } catch (error) {

--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/mongodb";
 import { PROFILES_COLLECTION } from "@/lib/models/Profile";
-import { ObjectId } from "mongodb";
 
 export async function GET(request: Request) {
   try {
@@ -10,23 +9,24 @@ export async function GET(request: Request) {
     const limit = parseInt(searchParams.get("limit") || "20");
     const seeking = searchParams.get("seeking");
     const location = searchParams.get("location");
+    const name = searchParams.get("name");
     const random = searchParams.get("random") === "true";
 
     const db = await getDb();
     const collection = db.collection(PROFILES_COLLECTION);
 
-    const query: any = { isPublic: true };
+    const query: Record<string, unknown> = { isPublic: true };
 
     if (seeking) {
       query.seeking = seeking;
     }
 
     if (location) {
-      // Simple case-insensitive search in background for location
-      query.background = { $regex: location, $options: "i" };
+      const escapedLocation = location.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      query.background = { $regex: escapedLocation, $options: "i" };
     }
 
-    let pipeline: any[] = [{ $match: query }];
+    const pipeline: Record<string, unknown>[] = [{ $match: query }];
 
     // Lookup user details (name)
     pipeline.push({
@@ -46,6 +46,7 @@ export async function GET(request: Request) {
         _id: 1,
         userId: 1,
         name: "$user.name",
+        email: "$user.email",
         avatarUrl: 1,
         seeking: 1,
         background: 1,
@@ -55,40 +56,63 @@ export async function GET(request: Request) {
       },
     });
 
+    // Name filter (applied after $project since name comes from $lookup)
+    if (name) {
+      const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      pipeline.push({
+        $match: { name: { $regex: escapedName, $options: "i" } },
+      });
+    }
+
     // Randomization or Pagination
     if (random) {
       pipeline.push({ $sample: { size: limit } });
-    } else {
-      pipeline.push({ $sort: { updatedAt: -1 } });
-      pipeline.push({ $skip: (page - 1) * limit });
-      pipeline.push({ $limit: limit });
+
+      const members = await collection.aggregate(pipeline).toArray();
+
+      return NextResponse.json({
+        members: members.map((m) => ({
+          ...m,
+          _id: m._id.toString(),
+          userId: m.userId.toString(),
+          createdAt: m.createdAt,
+          updatedAt: m.updatedAt,
+        })),
+        pagination: null,
+      });
     }
 
-    const members = await collection.aggregate(pipeline).toArray();
+    // Use $facet to get both results and total in one query
+    // (needed because name filter is post-lookup)
+    pipeline.push({
+      $facet: {
+        results: [
+          { $sort: { updatedAt: -1 } },
+          { $skip: (page - 1) * limit },
+          { $limit: limit },
+        ],
+        total: [{ $count: "count" }],
+      },
+    });
 
-    // Get total count for pagination (only if not random)
-    let total = 0;
-    if (!random) {
-      const countResult = await collection.countDocuments(query);
-      total = countResult;
-    }
+    const [facetResult] = await collection.aggregate(pipeline).toArray();
+    const members = facetResult?.results || [];
+    const total = facetResult?.total?.[0]?.count || 0;
 
     return NextResponse.json({
-      members: members.map((m) => ({
+      members: members.map((m: Record<string, unknown>) => ({
         ...m,
-        _id: m._id.toString(),
-        userId: m.userId.toString(),
+        _id: String(m._id),
+        userId: String(m.userId),
         createdAt: m.createdAt,
         updatedAt: m.updatedAt,
       })),
-      pagination: random
-        ? null
-        : {
-            page,
-            limit,
-            total,
-            pages: Math.ceil(total / limit),
-          },
+      pagination: {
+        page,
+        limit,
+        total,
+        pages: Math.ceil(total / limit),
+      },
     });
   } catch (error) {
     console.error("Get members error:", error);
@@ -98,4 +122,3 @@ export async function GET(request: Request) {
     );
   }
 }
-

--- a/src/app/hackathon/[slug]/page.tsx
+++ b/src/app/hackathon/[slug]/page.tsx
@@ -308,6 +308,35 @@ export default function HackathonLandingPage() {
         />
       )}
 
+      {/* Teams Section */}
+      <section className="border-t border-gray-800 px-4 py-16">
+        <div className="mx-auto max-w-6xl">
+          <h2 className="mb-2 text-center text-3xl font-bold">Teams</h2>
+          <p className="mb-8 text-center text-gray-400">
+            {isRegistered
+              ? "Join a team by clicking an open slot"
+              : "Register to join a team"}
+          </p>
+
+          {teams.length === 0 ? (
+            <div className="rounded-lg border border-gray-800 p-12 text-center">
+              <p className="text-gray-400">
+                Teams haven&apos;t been created yet. Check back soon!
+              </p>
+            </div>
+          ) : (
+            <TeamCardGrid
+              teams={teams}
+              hackathon={hackathon}
+              isRegistered={isRegistered}
+              currentUserId={user?.id}
+              onRefresh={fetchData}
+              slug={slug}
+            />
+          )}
+        </div>
+      </section>
+
       {/* Roles Section */}
       <section className="border-t border-gray-800 px-4 py-16">
         <div className="mx-auto max-w-4xl">
@@ -358,35 +387,6 @@ export default function HackathonLandingPage() {
               );
             })}
           </div>
-        </div>
-      </section>
-
-      {/* Teams Section */}
-      <section className="border-t border-gray-800 px-4 py-16">
-        <div className="mx-auto max-w-6xl">
-          <h2 className="mb-2 text-center text-3xl font-bold">Teams</h2>
-          <p className="mb-8 text-center text-gray-400">
-            {isRegistered
-              ? "Join a team by clicking an open slot"
-              : "Register to join a team"}
-          </p>
-
-          {teams.length === 0 ? (
-            <div className="rounded-lg border border-gray-800 p-12 text-center">
-              <p className="text-gray-400">
-                Teams haven&apos;t been created yet. Check back soon!
-              </p>
-            </div>
-          ) : (
-            <TeamCardGrid
-              teams={teams}
-              hackathon={hackathon}
-              isRegistered={isRegistered}
-              currentUserId={user?.id}
-              onRefresh={fetchData}
-              slug={slug}
-            />
-          )}
         </div>
       </section>
     </div>

--- a/src/app/hackathon/[slug]/page.tsx
+++ b/src/app/hackathon/[slug]/page.tsx
@@ -11,12 +11,8 @@ import {
   ROLE_DESCRIPTIONS,
   type Hackathon,
   type HackathonRegistration,
-  type HackathonTeam,
-  type HackathonTeamSlot,
+  type EnrichedHackathonTeam,
 } from "@/types";
-
-type EnrichedSlot = HackathonTeamSlot & { userName?: string | null };
-type EnrichedTeam = Omit<HackathonTeam, "slots"> & { slots: EnrichedSlot[] };
 
 export default function HackathonLandingPage() {
   const params = useParams();
@@ -25,7 +21,7 @@ export default function HackathonLandingPage() {
   const slug = params.slug as string;
 
   const [hackathon, setHackathon] = useState<Hackathon | null>(null);
-  const [teams, setTeams] = useState<EnrichedTeam[]>([]);
+  const [teams, setTeams] = useState<EnrichedHackathonTeam[]>([]);
   const [registration, setRegistration] =
     useState<HackathonRegistration | null>(null);
   const [participantCount, setParticipantCount] = useState(0);

--- a/src/app/members/[id]/page.tsx
+++ b/src/app/members/[id]/page.tsx
@@ -124,7 +124,7 @@ export default async function MemberProfilePage({
                 <h1 className="text-3xl font-bold text-white">{user.name}</h1>
                 <a
                   href={`mailto:${user.email}`}
-                  className="mt-1 inline-flex items-center gap-2 text-sm text-white/80 transition-colors hover:text-white"
+                  className="mt-1 inline-flex items-center gap-2 text-sm font-medium text-white underline decoration-white/40 transition-colors hover:decoration-white"
                 >
                   <FaEnvelope className="h-3.5 w-3.5" />
                   {user.email}

--- a/src/app/members/[id]/page.tsx
+++ b/src/app/members/[id]/page.tsx
@@ -13,6 +13,7 @@ import {
   FaUserFriends,
   FaUsers,
   FaMeetup,
+  FaEnvelope,
 } from "react-icons/fa";
 import { getProfileByUserId } from "@/lib/models/Profile";
 import { getUserById } from "@/lib/models/User";
@@ -121,10 +122,13 @@ export default async function MemberProfilePage({
               )}
               <div>
                 <h1 className="text-3xl font-bold text-white">{user.name}</h1>
-                {/* We might not want to show email publicly? Spec says: Avatar, Name, Title, Skills. 
-                    I'll hide email for now unless explicitly public. 
-                    The mock doesn't show email.
-                */}
+                <a
+                  href={`mailto:${user.email}`}
+                  className="mt-1 inline-flex items-center gap-2 text-sm text-white/80 transition-colors hover:text-white"
+                >
+                  <FaEnvelope className="h-3.5 w-3.5" />
+                  {user.email}
+                </a>
 
                 {/* Career Intentions Badges */}
                 <div className="mt-4 flex flex-wrap gap-2">
@@ -147,110 +151,114 @@ export default async function MemberProfilePage({
         </div>
 
         {/* Social Links Card */}
-        {(profile.links.linkedin ||
-          profile.links.github ||
-          profile.links.twitter ||
-          profile.links.portfolio ||
-          profile.links.meetup ||
-          profile.links.other) && (
-          <div className="rounded-lg border border-gray-800 bg-gray-900 p-6 shadow-lg">
-            <h2 className="mb-4 text-xl font-semibold text-white">
-              Connect With Me
-            </h2>
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-              {profile.links.linkedin && (
-                <a
-                  href={profile.links.linkedin}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="group flex items-center gap-3 rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 transition-all hover:border-blue-500 hover:bg-gray-700"
-                >
-                  <div className="text-blue-400 group-hover:text-blue-300">
-                    {getSocialIcon("linkedin")}
-                  </div>
-                  <span className="text-gray-300 group-hover:text-white">
-                    LinkedIn
-                  </span>
-                </a>
-              )}
-              {profile.links.github && (
-                <a
-                  href={profile.links.github}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="group flex items-center gap-3 rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 transition-all hover:border-blue-500 hover:bg-gray-700"
-                >
-                  <div className="text-blue-400 group-hover:text-blue-300">
-                    {getSocialIcon("github")}
-                  </div>
-                  <span className="text-gray-300 group-hover:text-white">
-                    GitHub
-                  </span>
-                </a>
-              )}
-              {profile.links.twitter && (
-                <a
-                  href={profile.links.twitter}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="group flex items-center gap-3 rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 transition-all hover:border-blue-500 hover:bg-gray-700"
-                >
-                  <div className="text-blue-400 group-hover:text-blue-300">
-                    {getSocialIcon("twitter")}
-                  </div>
-                  <span className="text-gray-300 group-hover:text-white">
-                    Twitter
-                  </span>
-                </a>
-              )}
-              {profile.links.portfolio && (
-                <a
-                  href={profile.links.portfolio}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="group flex items-center gap-3 rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 transition-all hover:border-blue-500 hover:bg-gray-700"
-                >
-                  <div className="text-blue-400 group-hover:text-blue-300">
-                    {getSocialIcon("portfolio")}
-                  </div>
-                  <span className="text-gray-300 group-hover:text-white">
-                    Portfolio
-                  </span>
-                </a>
-              )}
-              {profile.links.meetup && (
-                <a
-                  href={profile.links.meetup}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="group flex items-center gap-3 rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 transition-all hover:border-blue-500 hover:bg-gray-700"
-                >
-                  <div className="text-blue-400 group-hover:text-blue-300">
-                    {getSocialIcon("meetup")}
-                  </div>
-                  <span className="text-gray-300 group-hover:text-white">
-                    Meetup
-                  </span>
-                </a>
-              )}
-              {profile.links.other && (
-                <a
-                  href={profile.links.other}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="group flex items-center gap-3 rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 transition-all hover:border-blue-500 hover:bg-gray-700"
-                >
-                  <div className="text-blue-400 group-hover:text-blue-300">
-                    {getSocialIcon("other")}
-                  </div>
-                  <span className="text-gray-300 group-hover:text-white">
-                    Other Link
-                  </span>
-                </a>
-              )}
-            </div>
+        <div className="rounded-lg border border-gray-800 bg-gray-900 p-6 shadow-lg">
+          <h2 className="mb-4 text-xl font-semibold text-white">
+            Connect With Me
+          </h2>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <a
+              href={`mailto:${user.email}`}
+              className="group flex items-center gap-3 rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 transition-all hover:border-blue-500 hover:bg-gray-700"
+            >
+              <div className="text-blue-400 group-hover:text-blue-300">
+                <FaEnvelope className="h-5 w-5" />
+              </div>
+              <span className="text-gray-300 group-hover:text-white">
+                {user.email}
+              </span>
+            </a>
+            {profile.links.linkedin && (
+              <a
+                href={profile.links.linkedin}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group flex items-center gap-3 rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 transition-all hover:border-blue-500 hover:bg-gray-700"
+              >
+                <div className="text-blue-400 group-hover:text-blue-300">
+                  {getSocialIcon("linkedin")}
+                </div>
+                <span className="text-gray-300 group-hover:text-white">
+                  LinkedIn
+                </span>
+              </a>
+            )}
+            {profile.links.github && (
+              <a
+                href={profile.links.github}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group flex items-center gap-3 rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 transition-all hover:border-blue-500 hover:bg-gray-700"
+              >
+                <div className="text-blue-400 group-hover:text-blue-300">
+                  {getSocialIcon("github")}
+                </div>
+                <span className="text-gray-300 group-hover:text-white">
+                  GitHub
+                </span>
+              </a>
+            )}
+            {profile.links.twitter && (
+              <a
+                href={profile.links.twitter}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group flex items-center gap-3 rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 transition-all hover:border-blue-500 hover:bg-gray-700"
+              >
+                <div className="text-blue-400 group-hover:text-blue-300">
+                  {getSocialIcon("twitter")}
+                </div>
+                <span className="text-gray-300 group-hover:text-white">
+                  Twitter
+                </span>
+              </a>
+            )}
+            {profile.links.portfolio && (
+              <a
+                href={profile.links.portfolio}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group flex items-center gap-3 rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 transition-all hover:border-blue-500 hover:bg-gray-700"
+              >
+                <div className="text-blue-400 group-hover:text-blue-300">
+                  {getSocialIcon("portfolio")}
+                </div>
+                <span className="text-gray-300 group-hover:text-white">
+                  Portfolio
+                </span>
+              </a>
+            )}
+            {profile.links.meetup && (
+              <a
+                href={profile.links.meetup}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group flex items-center gap-3 rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 transition-all hover:border-blue-500 hover:bg-gray-700"
+              >
+                <div className="text-blue-400 group-hover:text-blue-300">
+                  {getSocialIcon("meetup")}
+                </div>
+                <span className="text-gray-300 group-hover:text-white">
+                  Meetup
+                </span>
+              </a>
+            )}
+            {profile.links.other && (
+              <a
+                href={profile.links.other}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group flex items-center gap-3 rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 transition-all hover:border-blue-500 hover:bg-gray-700"
+              >
+                <div className="text-blue-400 group-hover:text-blue-300">
+                  {getSocialIcon("other")}
+                </div>
+                <span className="text-gray-300 group-hover:text-white">
+                  Other Link
+                </span>
+              </a>
+            )}
           </div>
-        )}
+        </div>
 
         {/* Background Card */}
         {profile.background && (

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -9,6 +9,7 @@ type Member = {
   _id: string;
   userId: string;
   name: string;
+  email?: string;
   avatarUrl?: string;
   seeking: string | string[];
   background?: string;
@@ -21,7 +22,7 @@ export default function MembersPage() {
   const [hasMore, setHasMore] = useState(false);
 
   // Filters
-  const [location, setLocation] = useState("");
+  const [name, setName] = useState("");
   const [seeking, setSeeking] = useState("");
 
   const fetchMembers = async (pageToFetch: number, reset: boolean) => {
@@ -32,7 +33,7 @@ export default function MembersPage() {
         limit: "20",
       });
 
-      if (location) params.append("location", location);
+      if (name) params.append("name", name);
       if (seeking) params.append("seeking", seeking);
 
       const response = await fetch(`/api/members?${params.toString()}`);
@@ -99,10 +100,10 @@ export default function MembersPage() {
           >
             <div className="flex-1">
               <label
-                htmlFor="location"
+                htmlFor="name"
                 className="mb-1 block text-sm font-medium text-gray-300"
               >
-                Location (Search Bio)
+                Search by Name
               </label>
               <div className="relative">
                 <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
@@ -110,16 +111,12 @@ export default function MembersPage() {
                 </div>
                 <input
                   type="text"
-                  id="location"
-                  value={location}
-                  onChange={(e) => setLocation(e.target.value)}
-                  placeholder="Under development..."
-                  disabled
-                  className="block w-full rounded-md border border-gray-700 bg-gray-800 py-3 pl-10 text-gray-500 placeholder-gray-600 opacity-60 cursor-not-allowed sm:text-sm"
+                  id="name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Enter a name..."
+                  className="block w-full rounded-md border border-gray-700 bg-gray-800 py-3 pl-10 text-white placeholder-gray-500 focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
                 />
-                <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-yellow-500 font-medium">
-                  Coming Soon
-                </span>
               </div>
             </div>
 
@@ -151,8 +148,7 @@ export default function MembersPage() {
 
             <button
               type="submit"
-              disabled
-              className="inline-flex items-center justify-center rounded-md border border-transparent bg-blue-600 px-6 py-3 text-sm font-medium text-white shadow-sm opacity-50 cursor-not-allowed"
+              className="inline-flex items-center justify-center rounded-md border border-transparent bg-blue-600 px-6 py-3 text-sm font-medium text-white shadow-sm transition-colors hover:bg-blue-700"
             >
               Search
             </button>

--- a/src/components/hackathon/TeamCardGrid.tsx
+++ b/src/components/hackathon/TeamCardGrid.tsx
@@ -1,20 +1,19 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { FaEnvelope } from "react-icons/fa";
 import {
   ROLE_DESCRIPTIONS,
   type Hackathon,
-  type HackathonTeam,
-  type HackathonTeamSlot,
+  type EnrichedHackathonTeam,
   type HackathonRole,
 } from "@/types";
 import { useToast } from "@/components/ui/Toast";
 
-type EnrichedSlot = HackathonTeamSlot & { userName?: string | null };
-type EnrichedTeam = Omit<HackathonTeam, "slots"> & { slots: EnrichedSlot[] };
-
 interface Props {
-  teams: EnrichedTeam[];
+  teams: EnrichedHackathonTeam[];
   hackathon: Hackathon;
   isRegistered: boolean;
   currentUserId?: string;
@@ -92,7 +91,7 @@ export default function TeamCardGrid({
     }
   };
 
-  const filledCount = (team: EnrichedTeam) =>
+  const filledCount = (team: EnrichedHackathonTeam) =>
     team.slots.filter((s) => s.userId).length;
 
   return (
@@ -208,12 +207,62 @@ export default function TeamCardGrid({
                         </span>
 
                         {!isOpen && (
-                          <span
-                            className="truncate text-sm text-gray-400"
-                            title={isMe ? "You" : slot.userName || ""}
-                          >
-                            &mdash; {isMe ? "You" : slot.userName}
-                          </span>
+                          <div className="flex min-w-0 items-center gap-1.5">
+                            <span className="text-sm text-gray-400">
+                              &mdash;
+                            </span>
+
+                            {/* Avatar */}
+                            {slot.avatarUrl ? (
+                              <Image
+                                src={slot.avatarUrl}
+                                alt={slot.userName || ""}
+                                width={20}
+                                height={20}
+                                className="flex-shrink-0 rounded-full"
+                              />
+                            ) : (
+                              <span className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-gray-600 text-[10px] font-medium text-gray-300">
+                                {(slot.userName || "?")[0].toUpperCase()}
+                              </span>
+                            )}
+
+                            {/* Name — clickable if public profile */}
+                            {isMe ? (
+                              <span
+                                className="truncate text-sm text-blue-400"
+                                title="You"
+                              >
+                                You
+                              </span>
+                            ) : slot.isPublic && slot.userId ? (
+                              <Link
+                                href={`/members/${slot.userId}`}
+                                className="truncate text-sm text-gray-400 hover:text-blue-400 hover:underline"
+                                title={slot.userName || ""}
+                              >
+                                {slot.userName}
+                              </Link>
+                            ) : (
+                              <span
+                                className="truncate text-sm text-gray-400"
+                                title={slot.userName || ""}
+                              >
+                                {slot.userName}
+                              </span>
+                            )}
+
+                            {/* Email icon for teammates */}
+                            {slot.email && !isMe && (
+                              <a
+                                href={`mailto:${slot.email}`}
+                                title={slot.email}
+                                className="flex-shrink-0 text-gray-500 transition-colors hover:text-blue-400"
+                              >
+                                <FaEnvelope className="h-3 w-3" />
+                              </a>
+                            )}
+                          </div>
                         )}
                       </div>
 

--- a/src/components/members/MemberCard.tsx
+++ b/src/components/members/MemberCard.tsx
@@ -1,12 +1,19 @@
 import Image from "next/image";
 import Link from "next/link";
-import { FaMapMarkerAlt, FaBriefcase, FaUserFriends, FaUsers, FaLink } from "react-icons/fa";
+import {
+  FaBriefcase,
+  FaUserFriends,
+  FaUsers,
+  FaLink,
+  FaEnvelope,
+} from "react-icons/fa";
 
 type MemberCardProps = {
   member: {
     _id: string;
     userId: string;
     name: string;
+    email?: string;
     avatarUrl?: string;
     seeking: string | string[];
     background?: string;
@@ -43,7 +50,7 @@ export default function MemberCard({ member }: MemberCardProps) {
   // Extract location from background if possible (simple heuristic)
   // Or just display "Member"
   // For now, let's just show seeking tags.
-  
+
   const seekingArray = Array.isArray(member.seeking)
     ? member.seeking
     : [member.seeking];
@@ -69,11 +76,16 @@ export default function MemberCard({ member }: MemberCardProps) {
                 </div>
               )}
             </div>
-            <div>
+            <div className="min-w-0">
               <h3 className="text-lg font-semibold text-white group-hover:text-blue-400">
                 {member.name}
               </h3>
-              {/* Could extract title/role from background if we had a structured field */}
+              {member.email && (
+                <span className="flex items-center gap-1.5 text-xs text-gray-400">
+                  <FaEnvelope className="h-3 w-3 flex-shrink-0" />
+                  <span className="truncate">{member.email}</span>
+                </span>
+              )}
             </div>
           </div>
 
@@ -90,15 +102,14 @@ export default function MemberCard({ member }: MemberCardProps) {
           </div>
 
           {member.background && (
-             <div className="mt-4 text-sm text-gray-400 line-clamp-3">
-                 {/* Strip HTML tags for preview */}
-                 {member.background.replace(/<[^>]*>/g, '').substring(0, 150)}
-                 {member.background.length > 150 && "..."}
-             </div>
+            <div className="mt-4 line-clamp-3 text-sm text-gray-400">
+              {/* Strip HTML tags for preview */}
+              {member.background.replace(/<[^>]*>/g, "").substring(0, 150)}
+              {member.background.length > 150 && "..."}
+            </div>
           )}
         </div>
       </div>
     </Link>
   );
 }
-

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -158,6 +158,17 @@ export type HackathonTeam = {
   updatedAt: Date;
 };
 
+export type EnrichedTeamSlot = HackathonTeamSlot & {
+  userName?: string | null;
+  avatarUrl?: string | null;
+  isPublic?: boolean;
+  email?: string | null;
+};
+
+export type EnrichedHackathonTeam = Omit<HackathonTeam, "slots"> & {
+  slots: EnrichedTeamSlot[];
+};
+
 export type HackathonRegistration = {
   _id: string;
   hackathonId: string;


### PR DESCRIPTION
## Summary
- Show member emails on public profiles and member directory cards for community contact
- Make hackathon team card member names clickable links to profiles with initials avatars
- Add teammate email envelope icons on team cards (same-team and admin only, enforced server-side)
- Add name search to members directory (replaces disabled location search placeholder)
- Add shared `EnrichedTeamSlot` / `EnrichedHackathonTeam` types to eliminate duplication

## Files Changed
| File | Change |
|------|--------|
| `src/types/index.ts` | Add `EnrichedTeamSlot`, `EnrichedHackathonTeam` types |
| `src/app/api/hackathons/[slug]/teams/route.ts` | Enrich slots with profile data + conditional email |
| `src/components/hackathon/TeamCardGrid.tsx` | Clickable names, avatars, email icons |
| `src/app/hackathon/[slug]/page.tsx` | Import shared types |
| `src/app/api/members/route.ts` | Add `name` search param, add `email` to response, `$facet` pagination |
| `src/app/members/page.tsx` | Add name search input, enable Search button |
| `src/app/members/[id]/page.tsx` | Show email in header + Connect With Me section |
| `src/components/members/MemberCard.tsx` | Show email on member cards |

## Manual Review Steps

### 1. Members Directory — Email Visibility & Name Search
- [ ] Go to `/members`
- [ ] Verify each member card shows their **email** with an envelope icon below their name
- [ ] Type a partial name (e.g., "Ali") in "Search by Name" and click **Search** — only matching members appear
- [ ] Clear input and Search again — all members return
- [ ] Verify the **Looking For** filter still works alongside name search
- [ ] Try special characters in search (e.g., `.*`) — should not break (regex escaped server-side)

### 2. Public Member Profile — Email Display
- [ ] Click any member card to open their profile (`/members/[userId]`)
- [ ] Verify **email** shows as a clickable `mailto:` link below the name in the header card
- [ ] Verify **Connect With Me** section always appears with email as the first contact method
- [ ] Click the email link — should open email client

### 3. Hackathon Team Cards — Unauthenticated
- [ ] Go to `/hackathon/spring-2026` (logged out)
- [ ] Verify member names are **clickable links** to `/members/[userId]`
- [ ] Verify **initials avatars** appear next to each member name
- [ ] Verify **no email icons** are visible (unauthenticated users should not see emails here)

### 4. Hackathon Team Cards — Logged In (Team Member)
- [ ] Log in as a user assigned to a team
- [ ] Go to `/hackathon/spring-2026`
- [ ] On **your team** (green glow border): verify **email envelope icons** appear next to each teammate's name
- [ ] Verify your own slot shows "You" with **no** email icon
- [ ] On **other teams**: verify **no email icons** are visible
- [ ] Click an envelope icon — should open `mailto:` link with teammate's email

### 5. Hackathon Team Cards — Admin
- [ ] Log in as an admin user
- [ ] Verify **all teams** show email icons for all members

### 6. Edge Cases
- [ ] Member with private profile (`isPublic: false`): name should render as plain text (not a link) on team cards
- [ ] Empty search returns all members
- [ ] "No members found" empty state appears when search has no matches

## Test plan
- [x] `npm run lint` — clean (only pre-existing `<img>` warnings)
- [x] `npm run test` — 30/30 passing
- [ ] Manual QA per steps above

🤖 Generated with [Claude Code](https://claude.com/claude-code)