### PR TITLE
Release: Member directory emails & team detail pages

### DIFF
--- a/src/app/api/hackathons/[slug]/teams/[teamId]/__tests__/route.test.ts
+++ b/src/app/api/hackathons/[slug]/teams/[teamId]/__tests__/route.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// Mock dependencies before importing module under test
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: vi.fn(),
+  requireAdmin: vi.fn(),
+}));
+
+vi.mock("@/lib/validation", () => ({
+  parseJsonBody: vi.fn(),
+}));
+
+vi.mock("@/lib/models/Hackathon", () => ({
+  getHackathonBySlug: vi.fn(),
+}));
+
+vi.mock("@/lib/models/HackathonTeam", () => ({
+  getTeamById: vi.fn(),
+  updateHackathonTeam: vi.fn(),
+  deleteHackathonTeam: vi.fn(),
+}));
+
+vi.mock("@/lib/models/User", () => ({
+  getUsersByIds: vi.fn(),
+}));
+
+vi.mock("@/lib/models/Profile", () => ({
+  getProfilesByUserIds: vi.fn(),
+}));
+
+vi.mock("@/lib/jwt", () => ({
+  getAuthFromRequest: vi.fn(),
+}));
+
+import { PATCH } from "../route";
+import { requireAuth, requireAdmin } from "@/lib/auth-helpers";
+import { parseJsonBody } from "@/lib/validation";
+import { getHackathonBySlug } from "@/lib/models/Hackathon";
+import { getTeamById, updateHackathonTeam } from "@/lib/models/HackathonTeam";
+
+const mockRequireAuth = vi.mocked(requireAuth);
+const mockRequireAdmin = vi.mocked(requireAdmin);
+const mockParseJson = vi.mocked(parseJsonBody);
+const mockGetHackathon = vi.mocked(getHackathonBySlug);
+const mockGetTeam = vi.mocked(getTeamById);
+const mockUpdateTeam = vi.mocked(updateHackathonTeam);
+
+function makeRequest(body?: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/hackathons/test/teams/team1", {
+    method: "PATCH",
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+function makeUser(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: "user1",
+    email: "test@test.com",
+    passwordHash: "hash",
+    name: "Test User",
+    isAdmin: false,
+    emailVerified: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function makeHackathon() {
+  return {
+    _id: "hack1",
+    slug: "test",
+    name: "Test Hackathon",
+    description: "A test hackathon",
+    date: new Date(),
+    location: "Dallas",
+    status: "active" as const,
+    maxTeamSize: 6,
+    roles: ["Frontend Developer" as const],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+function makeTeam(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: "team1",
+    hackathonId: "hack1",
+    name: "Team Alpha",
+    description: "A great team",
+    order: 0,
+    slots: [
+      { role: "Frontend Developer" as const, userId: "user1", required: true },
+      { role: "Backend Engineer" as const, userId: undefined, required: true },
+    ],
+    createdBy: "admin1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+const params = { slug: "test", teamId: "team1" };
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("PATCH /api/hackathons/[slug]/teams/[teamId]", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockRequireAuth.mockResolvedValue({
+      ok: false,
+      response: new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+      }) as never,
+    });
+
+    const res = await PATCH(makeRequest(), { params });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when user is neither admin nor team member", async () => {
+    const user = makeUser({ _id: "outsider" });
+    mockRequireAuth.mockResolvedValue({
+      ok: true,
+      auth: { user: { id: "outsider", email: user.email } },
+      user,
+    } as never);
+    mockGetHackathon.mockResolvedValue(makeHackathon() as never);
+    mockGetTeam.mockResolvedValue(makeTeam() as never);
+
+    const res = await PATCH(makeRequest(), { params });
+    const body = await res.json();
+    expect(res.status).toBe(403);
+    expect(body.error).toBe("Forbidden");
+  });
+
+  it("succeeds when user is a team member", async () => {
+    const user = makeUser({ _id: "user1" });
+    mockRequireAuth.mockResolvedValue({
+      ok: true,
+      auth: { user: { id: "user1", email: user.email } },
+      user,
+    } as never);
+    mockGetHackathon.mockResolvedValue(makeHackathon() as never);
+    mockGetTeam.mockResolvedValue(makeTeam() as never);
+    mockParseJson.mockResolvedValue({
+      ok: true,
+      data: { name: "New Name", repoUrl: "https://github.com/test/repo" },
+    } as never);
+    const updatedTeam = makeTeam({
+      name: "New Name",
+      repoUrl: "https://github.com/test/repo",
+    });
+    mockUpdateTeam.mockResolvedValue(updatedTeam as never);
+
+    const res = await PATCH(makeRequest(), { params });
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.team.name).toBe("New Name");
+  });
+
+  it("succeeds when user is admin", async () => {
+    const user = makeUser({ _id: "admin1", isAdmin: true });
+    mockRequireAuth.mockResolvedValue({
+      ok: true,
+      auth: { user: { id: "admin1", email: user.email } },
+      user,
+    } as never);
+    mockGetHackathon.mockResolvedValue(makeHackathon() as never);
+    mockGetTeam.mockResolvedValue(makeTeam() as never);
+    mockParseJson.mockResolvedValue({
+      ok: true,
+      data: { name: "Admin Edit", description: "New desc", slots: [] },
+    } as never);
+    const updatedTeam = makeTeam({
+      name: "Admin Edit",
+      description: "New desc",
+    });
+    mockUpdateTeam.mockResolvedValue(updatedTeam as never);
+
+    const res = await PATCH(makeRequest(), { params });
+    expect(res.status).toBe(200);
+    // Admin can pass all fields including slots and description
+    expect(mockUpdateTeam).toHaveBeenCalledWith("team1", {
+      name: "Admin Edit",
+      description: "New desc",
+      slots: [],
+    });
+  });
+
+  it("strips slots for non-admin team members but allows description", async () => {
+    const user = makeUser({ _id: "user1" });
+    mockRequireAuth.mockResolvedValue({
+      ok: true,
+      auth: { user: { id: "user1", email: user.email } },
+      user,
+    } as never);
+    mockGetHackathon.mockResolvedValue(makeHackathon() as never);
+    mockGetTeam.mockResolvedValue(makeTeam() as never);
+    mockParseJson.mockResolvedValue({
+      ok: true,
+      data: {
+        name: "Team Edit",
+        description: "Updated desc",
+        slots: [],
+        repoUrl: "https://github.com/test/repo",
+        contactEmail: "team@test.com",
+      },
+    } as never);
+    const updatedTeam = makeTeam({ name: "Team Edit" });
+    mockUpdateTeam.mockResolvedValue(updatedTeam as never);
+
+    const res = await PATCH(makeRequest(), { params });
+    expect(res.status).toBe(200);
+    // Should pass allowed fields including description, but NOT slots
+    expect(mockUpdateTeam).toHaveBeenCalledWith("team1", {
+      name: "Team Edit",
+      description: "Updated desc",
+      repoUrl: "https://github.com/test/repo",
+      contactEmail: "team@test.com",
+    });
+  });
+
+  it("validates repoUrl format", async () => {
+    const user = makeUser({ _id: "user1" });
+    mockRequireAuth.mockResolvedValue({
+      ok: true,
+      auth: { user: { id: "user1", email: user.email } },
+      user,
+    } as never);
+    mockGetHackathon.mockResolvedValue(makeHackathon() as never);
+    mockGetTeam.mockResolvedValue(makeTeam() as never);
+    mockParseJson.mockResolvedValue({
+      ok: true,
+      data: { repoUrl: "not-a-url" },
+    } as never);
+
+    const res = await PATCH(makeRequest(), { params });
+    const body = await res.json();
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("Invalid repo URL");
+  });
+
+  it("validates contactEmail format", async () => {
+    const user = makeUser({ _id: "user1" });
+    mockRequireAuth.mockResolvedValue({
+      ok: true,
+      auth: { user: { id: "user1", email: user.email } },
+      user,
+    } as never);
+    mockGetHackathon.mockResolvedValue(makeHackathon() as never);
+    mockGetTeam.mockResolvedValue(makeTeam() as never);
+    mockParseJson.mockResolvedValue({
+      ok: true,
+      data: { contactEmail: "not-an-email" },
+    } as never);
+
+    const res = await PATCH(makeRequest(), { params });
+    const body = await res.json();
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("Invalid contact email");
+  });
+
+  it("allows empty string to clear repoUrl and contactEmail", async () => {
+    const user = makeUser({ _id: "user1" });
+    mockRequireAuth.mockResolvedValue({
+      ok: true,
+      auth: { user: { id: "user1", email: user.email } },
+      user,
+    } as never);
+    mockGetHackathon.mockResolvedValue(makeHackathon() as never);
+    mockGetTeam.mockResolvedValue(makeTeam() as never);
+    mockParseJson.mockResolvedValue({
+      ok: true,
+      data: { repoUrl: "", contactEmail: "" },
+    } as never);
+    const updatedTeam = makeTeam({ repoUrl: "", contactEmail: "" });
+    mockUpdateTeam.mockResolvedValue(updatedTeam as never);
+
+    const res = await PATCH(makeRequest(), { params });
+    expect(res.status).toBe(200);
+    expect(mockUpdateTeam).toHaveBeenCalledWith("team1", {
+      repoUrl: "",
+      contactEmail: "",
+    });
+  });
+
+  it("returns 409 when team name already exists", async () => {
+    const user = makeUser({ _id: "user1" });
+    mockRequireAuth.mockResolvedValue({
+      ok: true,
+      auth: { user: { id: "user1", email: user.email } },
+      user,
+    } as never);
+    mockGetHackathon.mockResolvedValue(makeHackathon() as never);
+    mockGetTeam.mockResolvedValue(makeTeam() as never);
+    mockParseJson.mockResolvedValue({
+      ok: true,
+      data: { name: "Duplicate Name" },
+    } as never);
+    const dupError = new Error("duplicate key") as Error & { code: number };
+    dupError.code = 11000;
+    mockUpdateTeam.mockRejectedValue(dupError);
+
+    const res = await PATCH(makeRequest(), { params });
+    const body = await res.json();
+    expect(res.status).toBe(409);
+    expect(body.error).toBe(
+      "A team with this name already exists in this hackathon",
+    );
+  });
+});

--- a/src/app/api/hackathons/[slug]/teams/[teamId]/route.ts
+++ b/src/app/api/hackathons/[slug]/teams/[teamId]/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireAdmin } from "@/lib/auth-helpers";
+import { requireAuth, requireAdmin } from "@/lib/auth-helpers";
 import { parseJsonBody } from "@/lib/validation";
 import { getUsersByIds } from "@/lib/models/User";
+import { getProfilesByUserIds } from "@/lib/models/Profile";
+import { getAuthFromRequest } from "@/lib/jwt";
 import { getHackathonBySlug } from "@/lib/models/Hackathon";
 import {
   getTeamById,
@@ -29,33 +31,51 @@ export async function GET(
       return NextResponse.json({ error: "Team not found" }, { status: 404 });
     }
 
-    // Batch-fetch user names
+    // Batch-fetch user names and profiles
     const slotUserIds = team.slots
       .filter((s) => s.userId)
       .map((s) => s.userId!);
     const userMap = await getUsersByIds(slotUserIds);
+    const profileMap = await getProfilesByUserIds(slotUserIds);
 
-    const slotsWithNames = team.slots.map((slot) => ({
-      ...slot,
-      userName: slot.userId
-        ? userMap.get(slot.userId)?.name || "Unknown"
-        : null,
-    }));
+    // Determine email visibility: admin or same-team member
+    const auth = getAuthFromRequest(request);
+    const currentUserId = auth?.user?.id;
+    const isAdmin = currentUserId
+      ? userMap.get(currentUserId)?.isAdmin === true
+      : false;
+    const isSameTeam = currentUserId
+      ? team.slots.some((s) => s.userId === currentUserId)
+      : false;
 
-    return NextResponse.json({ team: { ...team, slots: slotsWithNames } });
+    const enrichedSlots = team.slots.map((slot) => {
+      const user = slot.userId ? userMap.get(slot.userId) : undefined;
+      const profile = slot.userId ? profileMap.get(slot.userId) : undefined;
+      const showEmail = !!(slot.userId && user && (isAdmin || isSameTeam));
+
+      return {
+        ...slot,
+        userName: user?.name || (slot.userId ? "Unknown" : null),
+        avatarUrl: profile?.avatarUrl || null,
+        isPublic: profile?.isPublic || false,
+        email: showEmail ? user!.email : null,
+      };
+    });
+
+    return NextResponse.json({ team: { ...team, slots: enrichedSlots } });
   } catch (error) {
     console.error("Get team error:", error);
     return NextResponse.json({ error: "Failed to get team" }, { status: 500 });
   }
 }
 
-// PATCH /api/hackathons/[slug]/teams/[teamId] - Update team (admin only)
+// PATCH /api/hackathons/[slug]/teams/[teamId] - Update team (admin or team member)
 export async function PATCH(
   request: NextRequest,
   { params }: { params: { slug: string; teamId: string } },
 ) {
   try {
-    const authResult = await requireAdmin(request);
+    const authResult = await requireAuth(request);
     if (!authResult.ok) return authResult.response;
 
     const hackathon = await getHackathonBySlug(params.slug);
@@ -71,19 +91,71 @@ export async function PATCH(
       return NextResponse.json({ error: "Team not found" }, { status: 404 });
     }
 
+    // Allow admins or team members to edit
+    const isTeamMember = team.slots.some(
+      (s) => s.userId && s.userId === authResult.user._id,
+    );
+    if (!authResult.user.isAdmin && !isTeamMember) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
     const parsed = await parseJsonBody(request);
     if (!parsed.ok) return parsed.response;
     const body = parsed.data as Partial<{
       name: string;
       description: string;
+      repoUrl: string;
+      contactEmail: string;
       slots: HackathonTeamSlot[];
     }>;
 
-    const updated = await updateHackathonTeam(params.teamId, body);
+    // Validate repoUrl format if provided
+    if (body.repoUrl !== undefined && body.repoUrl !== "") {
+      try {
+        new URL(body.repoUrl);
+      } catch {
+        return NextResponse.json(
+          { error: "Invalid repo URL" },
+          { status: 400 },
+        );
+      }
+    }
+
+    // Validate contactEmail format if provided
+    if (body.contactEmail !== undefined && body.contactEmail !== "") {
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(body.contactEmail)) {
+        return NextResponse.json(
+          { error: "Invalid contact email" },
+          { status: 400 },
+        );
+      }
+    }
+
+    // Non-admin team members can only update name, description, repoUrl, contactEmail
+    let updatePayload: typeof body;
+    if (!authResult.user.isAdmin) {
+      updatePayload = {};
+      if (body.name !== undefined) updatePayload.name = body.name;
+      if (body.description !== undefined)
+        updatePayload.description = body.description;
+      if (body.repoUrl !== undefined) updatePayload.repoUrl = body.repoUrl;
+      if (body.contactEmail !== undefined)
+        updatePayload.contactEmail = body.contactEmail;
+    } else {
+      updatePayload = body;
+    }
+
+    const updated = await updateHackathonTeam(params.teamId, updatePayload);
 
     return NextResponse.json({ team: updated });
   } catch (error) {
     console.error("Update team error:", error);
+    if ((error as { code?: number }).code === 11000) {
+      return NextResponse.json(
+        { error: "A team with this name already exists in this hackathon" },
+        { status: 409 },
+      );
+    }
     return NextResponse.json(
       { error: "Failed to update team" },
       { status: 500 },

--- a/src/app/hackathon/[slug]/teams/[teamId]/__tests__/page.test.tsx
+++ b/src/app/hackathon/[slug]/teams/[teamId]/__tests__/page.test.tsx
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Mock dependencies
+vi.mock("next/navigation", () => ({
+  useParams: vi.fn(),
+  useRouter: vi.fn(() => ({ push: vi.fn(), back: vi.fn() })),
+}));
+
+vi.mock("@/components/auth/AuthProvider", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@/components/ui/Toast", () => ({
+  useToast: vi.fn(() => ({ toast: vi.fn() })),
+}));
+
+vi.mock("@/components/nav/TopNavBar", () => ({
+  default: () => <div data-testid="top-nav-bar" />,
+}));
+
+vi.mock("@/components/loaders/Loading", () => ({
+  default: () => <div data-testid="loading" />,
+}));
+
+import TeamPage from "../page";
+import { useParams } from "next/navigation";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+const mockUseParams = vi.mocked(useParams);
+const mockUseAuth = vi.mocked(useAuth);
+
+function makeTeam(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: "team1",
+    hackathonId: "hack1",
+    name: "Team Alpha",
+    description: "A great team",
+    repoUrl: "https://github.com/test/repo",
+    contactEmail: "team@test.com",
+    order: 0,
+    slots: [
+      {
+        role: "Frontend Developer",
+        userId: "user1",
+        required: true,
+        userName: "Alice",
+        avatarUrl: null,
+        isPublic: true,
+        email: "alice@test.com",
+      },
+      {
+        role: "Backend Engineer",
+        userId: undefined,
+        required: true,
+        userName: null,
+        avatarUrl: null,
+        isPublic: false,
+        email: null,
+      },
+    ],
+    createdBy: "admin1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeHackathon() {
+  return {
+    _id: "hack1",
+    slug: "test-hack",
+    name: "Test Hackathon",
+  };
+}
+
+function setupFetch(team = makeTeam(), hackathon = makeHackathon()) {
+  global.fetch = vi.fn((url: string | URL | Request) => {
+    const urlStr = typeof url === "string" ? url : url.toString();
+    if (urlStr.includes("/teams/")) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ team }),
+      });
+    }
+    if (urlStr.includes("/api/hackathons/")) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ hackathon }),
+      });
+    }
+    if (urlStr.includes("/api/auth/session")) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ isAdmin: false }),
+      });
+    }
+    return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockUseParams.mockReturnValue({ slug: "test-hack", teamId: "team1" });
+});
+
+describe("TeamPage", () => {
+  it("renders team name and members", async () => {
+    mockUseAuth.mockReturnValue({
+      user: null,
+      status: "unauthenticated",
+    } as never);
+    setupFetch();
+
+    render(<TeamPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Team Alpha" }),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText(/Frontend Developer/)).toBeInTheDocument();
+  });
+
+  it("shows edit button for team member", async () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: "user1", email: "alice@test.com" },
+      status: "authenticated",
+    } as never);
+    setupFetch();
+
+    render(<TeamPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument();
+    });
+  });
+
+  it("hides edit button for non-member", async () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: "outsider", email: "outsider@test.com" },
+      status: "authenticated",
+    } as never);
+    setupFetch();
+
+    render(<TeamPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Team Alpha" }),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("button", { name: /edit/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("edit mode shows prefilled inputs", async () => {
+    const user = userEvent.setup();
+    mockUseAuth.mockReturnValue({
+      user: { id: "user1", email: "alice@test.com" },
+      status: "authenticated",
+    } as never);
+    setupFetch();
+
+    render(<TeamPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    const nameInput = screen.getByLabelText(/team name/i);
+    const repoInput = screen.getByLabelText(/repo/i);
+    const emailInput = screen.getByLabelText(/contact email/i);
+
+    expect(nameInput).toHaveValue("Team Alpha");
+    expect(repoInput).toHaveValue("https://github.com/test/repo");
+    expect(emailInput).toHaveValue("team@test.com");
+  });
+
+  it("save calls PATCH and exits edit mode", async () => {
+    const user = userEvent.setup();
+    mockUseAuth.mockReturnValue({
+      user: { id: "user1", email: "alice@test.com" },
+      status: "authenticated",
+    } as never);
+    setupFetch();
+
+    render(<TeamPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+
+    const nameInput = screen.getByLabelText(/team name/i);
+    await user.clear(nameInput);
+    await user.type(nameInput, "New Name");
+
+    // Mock the PATCH response
+    const updatedTeam = makeTeam({ name: "New Name" });
+    (global.fetch as ReturnType<typeof vi.fn>).mockImplementation(
+      (url: string | URL | Request, options?: RequestInit) => {
+        const urlStr = typeof url === "string" ? url : url.toString();
+        if (urlStr.includes("/teams/") && options?.method === "PATCH") {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ team: updatedTeam }),
+          });
+        }
+        if (urlStr.includes("/teams/")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ team: updatedTeam }),
+          });
+        }
+        if (urlStr.includes("/api/hackathons/")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ hackathon: makeHackathon() }),
+          });
+        }
+        if (urlStr.includes("/api/auth/session")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ isAdmin: false }),
+          });
+        }
+        return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
+      },
+    );
+
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "New Name" }),
+      ).toBeInTheDocument();
+    });
+
+    // Verify PATCH was called
+    const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    const patchCall = calls.find(
+      (c: [string | URL | Request, RequestInit | undefined]) =>
+        c[1]?.method === "PATCH",
+    );
+    expect(patchCall).toBeTruthy();
+  });
+});

--- a/src/app/hackathon/[slug]/teams/[teamId]/page.tsx
+++ b/src/app/hackathon/[slug]/teams/[teamId]/page.tsx
@@ -1,0 +1,390 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import Image from "next/image";
+import { FaGithub, FaEnvelope, FaArrowLeft, FaPen } from "react-icons/fa";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { useToast } from "@/components/ui/Toast";
+import TopNavBar from "@/components/nav/TopNavBar";
+import Loading from "@/components/loaders/Loading";
+import type { EnrichedHackathonTeam } from "@/types";
+
+export default function TeamPage() {
+  const params = useParams();
+  const router = useRouter();
+  const { user, status } = useAuth();
+  const { toast } = useToast();
+  const slug = params.slug as string;
+  const teamId = params.teamId as string;
+
+  const [team, setTeam] = useState<EnrichedHackathonTeam | null>(null);
+  const [hackathonName, setHackathonName] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  // Edit form state
+  const [editName, setEditName] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+  const [editRepoUrl, setEditRepoUrl] = useState("");
+  const [editContactEmail, setEditContactEmail] = useState("");
+
+  const fetchTeam = useCallback(async () => {
+    try {
+      const t = Date.now();
+      const [teamRes, hackRes] = await Promise.all([
+        fetch(`/api/hackathons/${slug}/teams/${teamId}?_t=${t}`, {
+          cache: "no-store",
+        }),
+        fetch(`/api/hackathons/${slug}?_t=${t}`, { cache: "no-store" }),
+      ]);
+
+      if (!teamRes.ok) {
+        setTeam(null);
+        setLoading(false);
+        return;
+      }
+
+      const teamData = await teamRes.json();
+      setTeam(teamData.team);
+      setEditName(teamData.team.name || "");
+      setEditDescription(teamData.team.description || "");
+      setEditRepoUrl(teamData.team.repoUrl || "");
+      setEditContactEmail(teamData.team.contactEmail || "");
+
+      if (hackRes.ok) {
+        const hackData = await hackRes.json();
+        setHackathonName(hackData.hackathon?.name || "");
+      }
+    } catch {
+      setTeam(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [slug, teamId]);
+
+  useEffect(() => {
+    fetchTeam();
+  }, [fetchTeam]);
+
+  // Check admin status
+  useEffect(() => {
+    if (status === "authenticated" && user) {
+      fetch("/api/auth/session")
+        .then((r) => r.json())
+        .then((data) => {
+          setIsAdmin(data.isAdmin || data.user?.isAdmin || false);
+        })
+        .catch(() => {});
+    }
+  }, [status, user]);
+
+  const isTeamMember = team?.slots.some(
+    (s) => s.userId && s.userId === user?.id,
+  );
+  const canEdit = isAdmin || isTeamMember;
+
+  const handleSave = async () => {
+    if (!team) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/hackathons/${slug}/teams/${teamId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: editName,
+          description: editDescription,
+          repoUrl: editRepoUrl,
+          contactEmail: editContactEmail,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        toast(data.error || "Failed to update team", "error");
+        return;
+      }
+
+      toast("Team updated successfully", "success");
+      setEditing(false);
+      await fetchTeam();
+    } catch {
+      toast("Failed to update team", "error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setEditing(false);
+    setEditName(team?.name || "");
+    setEditDescription(team?.description || "");
+    setEditRepoUrl(team?.repoUrl || "");
+    setEditContactEmail(team?.contactEmail || "");
+  };
+
+  if (loading) return <Loading />;
+
+  if (!team) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center bg-black text-white">
+        <h1 className="mb-4 text-4xl font-bold">Team Not Found</h1>
+        <button
+          onClick={() => router.back()}
+          className="rounded-lg bg-blue-600 px-6 py-3 font-medium transition-colors hover:bg-blue-700"
+        >
+          Go Back
+        </button>
+      </div>
+    );
+  }
+
+  const filledSlots = team.slots.filter((s) => s.userId);
+  const totalSlots = team.slots.length;
+
+  return (
+    <div className="min-h-screen bg-black text-white">
+      <TopNavBar />
+
+      <div className="mx-auto max-w-3xl px-4 py-8">
+        {/* Breadcrumb */}
+        <div className="mb-6 flex items-center gap-2 text-sm text-gray-400">
+          <Link
+            href={`/hackathon/${slug}`}
+            className="transition-colors hover:text-white"
+          >
+            {hackathonName || "Hackathon"}
+          </Link>
+          <span>/</span>
+          <span className="text-white">{team.name}</span>
+        </div>
+
+        {/* Back link */}
+        <Link
+          href={`/hackathon/${slug}`}
+          className="mb-6 inline-flex items-center gap-2 text-sm text-gray-400 transition-colors hover:text-white"
+        >
+          <FaArrowLeft className="h-3 w-3" />
+          Back to hackathon
+        </Link>
+
+        {/* Team Header */}
+        <div className="mb-6 mt-4 rounded-xl border border-gray-800 bg-gray-900/50 p-6">
+          <div className="flex items-start justify-between">
+            <div>
+              <h1 className="text-2xl font-bold">{team.name}</h1>
+              {team.description && (
+                <p className="mt-2 text-gray-400">{team.description}</p>
+              )}
+            </div>
+            {canEdit && !editing && (
+              <button
+                onClick={() => setEditing(true)}
+                className="flex items-center gap-2 rounded-lg border border-gray-700 px-3 py-2 text-sm text-gray-300 transition-colors hover:border-gray-500 hover:text-white"
+                aria-label="Edit team"
+              >
+                <FaPen className="h-3 w-3" />
+                Edit
+              </button>
+            )}
+          </div>
+
+          {/* Progress */}
+          <div className="mt-4 text-sm text-gray-400">
+            {filledSlots.length}/{totalSlots} members
+          </div>
+        </div>
+
+        {/* Team Info */}
+        <div className="mb-6 rounded-xl border border-gray-800 bg-gray-900/50 p-6">
+          <h2 className="mb-4 text-lg font-semibold">Team Info</h2>
+
+          {editing ? (
+            <div className="space-y-4">
+              <div>
+                <label
+                  htmlFor="team-name"
+                  className="mb-1 block text-sm font-medium text-gray-400"
+                >
+                  Team Name
+                </label>
+                <input
+                  id="team-name"
+                  type="text"
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                  className="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2 text-white focus:border-blue-500 focus:outline-none"
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="team-description"
+                  className="mb-1 block text-sm font-medium text-gray-400"
+                >
+                  Description
+                </label>
+                <textarea
+                  id="team-description"
+                  value={editDescription}
+                  onChange={(e) => setEditDescription(e.target.value)}
+                  rows={3}
+                  placeholder="What is your team building?"
+                  className="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2 text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="repo-url"
+                  className="mb-1 block text-sm font-medium text-gray-400"
+                >
+                  Repository URL
+                </label>
+                <input
+                  id="repo-url"
+                  type="url"
+                  value={editRepoUrl}
+                  onChange={(e) => setEditRepoUrl(e.target.value)}
+                  placeholder="https://github.com/org/repo"
+                  className="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2 text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="contact-email"
+                  className="mb-1 block text-sm font-medium text-gray-400"
+                >
+                  Contact Email
+                </label>
+                <input
+                  id="contact-email"
+                  type="email"
+                  value={editContactEmail}
+                  onChange={(e) => setEditContactEmail(e.target.value)}
+                  placeholder="team@example.com"
+                  className="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2 text-white placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+                />
+              </div>
+
+              <div className="flex gap-3">
+                <button
+                  onClick={handleSave}
+                  disabled={saving}
+                  className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
+                >
+                  {saving ? "Saving..." : "Save"}
+                </button>
+                <button
+                  onClick={handleCancel}
+                  disabled={saving}
+                  className="rounded-lg border border-gray-700 px-4 py-2 text-sm font-medium text-gray-300 transition-colors hover:border-gray-500 hover:text-white disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              <div className="flex items-center gap-3">
+                <FaGithub className="h-5 w-5 text-gray-400" />
+                {team.repoUrl ? (
+                  <a
+                    href={team.repoUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-400 transition-colors hover:text-blue-300 hover:underline"
+                  >
+                    {team.repoUrl}
+                  </a>
+                ) : (
+                  <span className="text-gray-500">No repository URL set</span>
+                )}
+              </div>
+              <div className="flex items-center gap-3">
+                <FaEnvelope className="h-5 w-5 text-gray-400" />
+                {team.contactEmail ? (
+                  <a
+                    href={`mailto:${team.contactEmail}`}
+                    className="text-blue-400 transition-colors hover:text-blue-300 hover:underline"
+                  >
+                    {team.contactEmail}
+                  </a>
+                ) : (
+                  <span className="text-gray-500">No contact email set</span>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Team Members */}
+        <div className="rounded-xl border border-gray-800 bg-gray-900/50 p-6">
+          <h2 className="mb-4 text-lg font-semibold">Team Members</h2>
+          <div className="space-y-3">
+            {team.slots.map((slot, i) => (
+              <div
+                key={i}
+                className="flex items-center gap-4 rounded-lg border border-gray-800 bg-gray-800/50 p-3"
+              >
+                {/* Avatar */}
+                <div className="h-10 w-10 flex-shrink-0 overflow-hidden rounded-full bg-gray-700">
+                  {slot.userId && slot.avatarUrl ? (
+                    <Image
+                      src={slot.avatarUrl}
+                      alt={slot.userName || "Member"}
+                      width={40}
+                      height={40}
+                      className="h-full w-full object-cover"
+                    />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center text-sm text-gray-400">
+                      {slot.userId
+                        ? (slot.userName || "?").charAt(0).toUpperCase()
+                        : "?"}
+                    </div>
+                  )}
+                </div>
+
+                {/* Info */}
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    {slot.userId ? (
+                      <>
+                        {slot.isPublic ? (
+                          <Link
+                            href={`/members/${slot.userId}`}
+                            className="font-medium text-white hover:text-blue-400"
+                          >
+                            {slot.userName}
+                          </Link>
+                        ) : (
+                          <span className="font-medium text-white">
+                            {slot.userName}
+                          </span>
+                        )}
+                        {slot.email && (
+                          <a
+                            href={`mailto:${slot.email}`}
+                            className="text-gray-400 hover:text-blue-400"
+                            title={slot.email}
+                          >
+                            <FaEnvelope className="h-3 w-3" />
+                          </a>
+                        )}
+                      </>
+                    ) : (
+                      <span className="text-gray-500">Open</span>
+                    )}
+                  </div>
+                  <span className="text-xs text-gray-400">{slot.role}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/hackathon/TeamCardGrid.tsx
+++ b/src/components/hackathon/TeamCardGrid.tsx
@@ -146,7 +146,14 @@ export default function TeamCardGrid({
               {/* Header */}
               <div className="relative mb-4 flex items-start justify-between">
                 <div>
-                  <h3 className="text-lg font-bold">{team.name}</h3>
+                  <h3 className="text-lg font-bold">
+                    <Link
+                      href={`/hackathon/${slug}/teams/${team._id}`}
+                      className="transition-colors hover:text-blue-400 hover:underline"
+                    >
+                      {team.name}
+                    </Link>
+                  </h3>
                   {team.description && (
                     <p className="mt-1 text-sm text-gray-400">
                       {team.description}

--- a/src/lib/models/HackathonTeam.ts
+++ b/src/lib/models/HackathonTeam.ts
@@ -37,6 +37,8 @@ function docToTeam(doc: Record<string, unknown>): HackathonTeam {
     hackathonId: (doc.hackathonId as ObjectId).toString(),
     name: doc.name as string,
     description: (doc.description as string) || undefined,
+    repoUrl: (doc.repoUrl as string) || undefined,
+    contactEmail: (doc.contactEmail as string) || undefined,
     order: (doc.order as number) ?? 0,
     slots: deserializeSlots(doc.slots as Record<string, unknown>[]),
     createdBy: (doc.createdBy as ObjectId).toString(),
@@ -114,6 +116,8 @@ export async function updateHackathonTeam(
   data: Partial<{
     name: string;
     description: string;
+    repoUrl: string;
+    contactEmail: string;
     slots: HackathonTeamSlot[];
   }>,
 ): Promise<HackathonTeam | null> {
@@ -126,6 +130,9 @@ export async function updateHackathonTeam(
 
   if (data.name !== undefined) updateData.name = data.name;
   if (data.description !== undefined) updateData.description = data.description;
+  if (data.repoUrl !== undefined) updateData.repoUrl = data.repoUrl;
+  if (data.contactEmail !== undefined)
+    updateData.contactEmail = data.contactEmail;
   if (data.slots !== undefined) updateData.slots = serializeSlots(data.slots);
 
   const result = await collection.findOneAndUpdate(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -151,6 +151,8 @@ export type HackathonTeam = {
   hackathonId: string;
   name: string;
   description?: string;
+  repoUrl?: string;
+  contactEmail?: string;
   order: number;
   slots: HackathonTeamSlot[];
   createdBy: string;


### PR DESCRIPTION
## Summary
- **Member directory emails & team contact features** — add email display to member profiles/directory and team contact info for hackathon teams
- **Hackathon team detail/edit page** — new page at `/hackathon/[slug]/teams/[teamId]` with view/edit mode for team name, description, repo URL, and contact email
- **PATCH auth broadened** from admin-only to admin-or-team-member with field stripping (non-admins cannot modify slots)
- **UI improvements** — Teams section moved above Team Roles on hackathon page, email text contrast fix on member profiles, slack link update

## Key Changes
- New `repoUrl` and `contactEmail` fields on `HackathonTeam` model (backward compatible)
- Team names in `TeamCardGrid` now link to dedicated team detail pages
- Duplicate team name detection (409) on rename
- GET team endpoint enriched with avatars, profiles, and scoped email visibility
- 14 new tests (9 API route + 5 component)

## Test plan
- [x] `npm run lint` passes
- [x] `npm run test` passes (44 tests)
- [x] `npm run build` succeeds
- [ ] Manual: navigate to hackathon → click team name → view team detail page
- [ ] Manual: as team member, click Edit → update all fields → Save
- [ ] Manual: as non-member, verify Edit button is hidden
- [ ] Manual: verify duplicate team name shows error toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)